### PR TITLE
Allow create table constraints to use data types as symbols

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1253,7 +1253,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	}
 
 	public function testTypeKeywordsAsKeyNames() {
-		// CREATE TABLE with ON UPDATE
+		// CREATE TABLE with a data type as a key name
 		$this->assertQuery(
 			'CREATE TABLE `_tmp_table` (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1293,8 +1293,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			'CREATE TABLE `_tmp_table` (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				`INDEX` timestamp,
-				PRIMARY KEY (`id`),
-				KEY numeric (numeric)
+				PRIMARY KEY (`id`)
 			);'
 		);
 		$results = $this->assertQuery( 'DESCRIBE _tmp_table;' );

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1258,7 +1258,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			'CREATE TABLE `_tmp_table` (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				`timestamp` datetime NOT NULL,
-				`numeric` int(11) NOT NULL,
+				`INDEX` timestamp,
 				PRIMARY KEY (`id`),
 				KEY `timestamp` (`timestamp`),
 				KEY numeric (numeric)
@@ -1284,11 +1284,11 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					'Extra'   => '',
 				),
 				(object) array(
-					'Field'   => 'numeric',
-					'Type'    => 'int(11)',
-					'Null'    => 'NO',
+					'Field'   => 'INDEX',
+					'Type'    => 'timestamp',
+					'Null'    => 'YES',
 					'Key'     => '',
-					'Default' => '0',
+					'Default' => null,
 					'Extra'   => '',
 				),
 			),

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1252,20 +1252,19 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertNull( $result[0]->updated_at );
 	}
 
-	public function testTimestampColumnNamedTimestamp() {
+	public function testTypeKeywordsAsKeyNames() {
 		// CREATE TABLE with ON UPDATE
 		$this->assertQuery(
-			"CREATE TABLE `_tmp_table` (
+			'CREATE TABLE `_tmp_table` (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				`timestamp` datetime NOT NULL,
 				`numeric` int(11) NOT NULL,
 				PRIMARY KEY (`id`),
-				KEY timestamp (timestamp),
+				KEY `timestamp` (`timestamp`),
 				KEY numeric (numeric)
-			);"
+			);'
 		);
 		$results = $this->assertQuery( 'DESCRIBE _tmp_table;' );
-		var_dump( $results );
 		$this->assertEquals(
 			array(
 				(object) array(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1252,6 +1252,51 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertNull( $result[0]->updated_at );
 	}
 
+	public function testTimestampColumnNamedTimestamp() {
+		// CREATE TABLE with ON UPDATE
+		$this->assertQuery(
+			"CREATE TABLE `_tmp_table` (
+				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				`timestamp` datetime NOT NULL,
+				`numeric` int(11) NOT NULL,
+				PRIMARY KEY (`id`),
+				KEY timestamp (timestamp),
+				KEY numeric (numeric)
+			);"
+		);
+		$results = $this->assertQuery( 'DESCRIBE _tmp_table;' );
+		var_dump( $results );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'Field'   => 'id',
+					'Type'    => 'bigint(20) unsigned',
+					'Null'    => 'NO',
+					'Key'     => 'PRI',
+					'Default' => '0',
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'timestamp',
+					'Type'    => 'datetime',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => null,
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'numeric',
+					'Type'    => 'int(11)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => '0',
+					'Extra'   => '',
+				),
+			),
+			$results
+		);
+	}
+
 	public function testColumnWithOnUpdateAndNoIdField() {
 		// CREATE TABLE with ON UPDATE
 		$this->assertQuery(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1252,16 +1252,14 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertNull( $result[0]->updated_at );
 	}
 
-	public function testTypeKeywordsAsKeyNames() {
+	public function testDataTypeKeywordsAsKeyNames() {
 		// CREATE TABLE with a data type as a key name
 		$this->assertQuery(
 			'CREATE TABLE `_tmp_table` (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				`timestamp` datetime NOT NULL,
-				`INDEX` timestamp,
 				PRIMARY KEY (`id`),
 				KEY `timestamp` (`timestamp`),
-				KEY numeric (numeric)
 			);'
 		);
 		$results = $this->assertQuery( 'DESCRIBE _tmp_table;' );
@@ -1281,6 +1279,33 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => null,
+					'Extra'   => '',
+				),
+			),
+			$results
+		);
+	}
+
+
+	public function testReservedKeywordsAsFieldNames() {
+		// CREATE TABLE with a reserved keyword as a field name
+		$this->assertQuery(
+			'CREATE TABLE `_tmp_table` (
+				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				`INDEX` timestamp,
+				PRIMARY KEY (`id`),
+				KEY numeric (numeric)
+			);'
+		);
+		$results = $this->assertQuery( 'DESCRIBE _tmp_table;' );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'Field'   => 'id',
+					'Type'    => 'bigint(20) unsigned',
+					'Null'    => 'NO',
+					'Key'     => 'PRI',
+					'Default' => '0',
 					'Extra'   => '',
 				),
 				(object) array(

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1004,7 +1004,7 @@ class WP_SQLite_Translator {
 			$this->rewriter->replace_all( array() );
 
 			/*
-			 * Decide how to parse the current line. We ehttps://github.com/WordPress/sqlite-database-integration/blob/eba8ab5a92d95d332cdbcdf008c7328906027cc2/wp-includes/sqlite/class-wp-sqlite-translator.php#L1007xpect either:
+			 * Decide how to parse the current line. We expect either:
 			 *
 			 * Field definition, e.g.:
 			 *     `my_field` varchar(255) NOT NULL DEFAULT 'foo'

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1020,7 +1020,7 @@ class WP_SQLite_Translator {
 					WP_SQLite_Token::FLAG_KEYWORD_DATA_TYPE
 				) && ! $current_token->matches(
 					WP_SQLite_Token::TYPE_KEYWORD,
-					WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+					WP_SQLite_Token::FLAG_KEYWORD_RESERVED
 				)
 			) {
 				$result->fields[] = $this->parse_mysql_create_table_field();

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1004,12 +1004,21 @@ class WP_SQLite_Translator {
 			$this->rewriter->replace_all( array() );
 
 			/*
-			 * Decide how to parse the current line. We expect either:
+			 * Decide how to parse the current line. We ehttps://github.com/WordPress/sqlite-database-integration/blob/eba8ab5a92d95d332cdbcdf008c7328906027cc2/wp-includes/sqlite/class-wp-sqlite-translator.php#L1007xpect either:
 			 *
 			 * Field definition, e.g.:
 			 *     `my_field` varchar(255) NOT NULL DEFAULT 'foo'
 			 * Constraint definition, e.g.:
 			 *      PRIMARY KEY (`my_field`)
+			 *
+			 * Lexer does not seem to reliably understand whether the
+			 * first token is a field name or a reserved keyword, so
+			 * alongside checking for the reserved keyword, we'll also
+			 * check whether the second non-whitespace token is a data type.
+			 *
+			 * By checking for the reserved keyword, we can be sure that
+			 * we're not parsing a constraint as a field when the
+			 * constraint symbol matches a data type.
 			 */
 			$current_token = $this->rewriter->peek();
 			$second_token  = $this->rewriter->peek_nth( 2 );

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1017,13 +1017,20 @@ class WP_SQLite_Translator {
 			 * token is a data type.
 			 */
 			$second_token = $this->rewriter->peek_nth( 2 );
+			$current_token = $this->rewriter->peek();
 
 			if ( $second_token->matches(
 				WP_SQLite_Token::TYPE_KEYWORD,
 				WP_SQLite_Token::FLAG_KEYWORD_DATA_TYPE
+			) && !$current_token->matches(
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+				array( 'KEY' )
 			) ) {
+				echo 'field';
 				$result->fields[] = $this->parse_mysql_create_table_field();
 			} else {
+				echo 'constraint';
 				$result->constraints[] = $this->parse_mysql_create_table_constraint();
 			}
 
@@ -1236,6 +1243,7 @@ class WP_SQLite_Translator {
 		}
 
 		$result->value = $this->normalize_mysql_index_type( $constraint->value );
+		echo 'result value: ' . $result->value . "\n";
 		if ( $result->value ) {
 			$this->rewriter->skip(); // Constraint type.
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1010,27 +1010,21 @@ class WP_SQLite_Translator {
 			 *     `my_field` varchar(255) NOT NULL DEFAULT 'foo'
 			 * Constraint definition, e.g.:
 			 *      PRIMARY KEY (`my_field`)
-			 *
-			 * Lexer does not seem to reliably understand whether the
-			 * first token is a field name or a reserved keyword, so
-			 * instead we'll check whether the second non-whitespace
-			 * token is a data type.
 			 */
-			$second_token = $this->rewriter->peek_nth( 2 );
 			$current_token = $this->rewriter->peek();
+			$second_token  = $this->rewriter->peek_nth( 2 );
 
-			if ( $second_token->matches(
-				WP_SQLite_Token::TYPE_KEYWORD,
-				WP_SQLite_Token::FLAG_KEYWORD_DATA_TYPE
-			) && !$current_token->matches(
-				WP_SQLite_Token::TYPE_KEYWORD,
-				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-				array( 'KEY' )
-			) ) {
-				echo 'field';
+			if (
+				$second_token->matches(
+					WP_SQLite_Token::TYPE_KEYWORD,
+					WP_SQLite_Token::FLAG_KEYWORD_DATA_TYPE
+				) && ! $current_token->matches(
+					WP_SQLite_Token::TYPE_KEYWORD,
+					WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+				)
+			) {
 				$result->fields[] = $this->parse_mysql_create_table_field();
 			} else {
-				echo 'constraint';
 				$result->constraints[] = $this->parse_mysql_create_table_constraint();
 			}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1237,7 +1237,6 @@ class WP_SQLite_Translator {
 		}
 
 		$result->value = $this->normalize_mysql_index_type( $constraint->value );
-		echo 'result value: ' . $result->value . "\n";
 		if ( $result->value ) {
 			$this->rewriter->skip(); // Constraint type.
 


### PR DESCRIPTION
Sometimes a data type keyword like `timestamp` will be used as the symbol when defining a CREATE TABLE constraint, for example: 
```
CREATE TABLE test (
  `timestamp` datetime
  KEY timestamp (timestamp)
)
```

This will currently lead to an error where the SQL query line will be incorrectly detected as a table field instead of a table constraint. 
As a result a new table field with the constraint keyword as the name will be added to the table, instead of creating a constraint. In the above example, a column with the name _KEY_ and data type timestamp is added.

This is because [we check for field lines by checking if the next token is a valid data type](https://github.com/Automattic/sqlite-database-integration/blob/develop/wp-includes/sqlite/class-wp-sqlite-translator.php#L1021) and because the constraint symbol matches a data type (_timestamp_) the code incorrectly assumes the line is a table field instead of a constraint.

To resolve this issue the PR adds a check to see if the current keyword matches a reserved keyword.
This prevents the parser from parsing the line as a field when a condition symbol matches a data type.

In case a field name is a reserved keyword, it will be parsed as a field line only if the field name is wrapped in quotes.
This [matches the behavior of MySQL.](https://dev.mysql.com/doc/refman/8.4/en/identifiers.html)
> An identifier may be quoted or unquoted. If an identifier contains special characters or is a reserved word, you must quote it whenever you refer to it.

Related Studio issue: https://github.com/Automattic/dotcom-forge/issues/10221

## Testing instructions 

- CI


