### PR TITLE
Select information_schema using a nested query to support WHERE, ORDER BY, and AS

### DIFF
--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -77,32 +77,39 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 		$result = $this->assertQuery( "SELECT * FROM information_schema.tables WHERE TABLE_NAME = 'wp_options'" );
 		$this->assertEquals(
 			array(
-				'TABLE_NAME' => 'wp_options',
-				'TABLE_TYPE' => 'BASE TABLE',
-				'TABLE_SCHEMA' => 'database',
-				'ENGINE' => 'InnoDB',
+				'TABLE_CATALOG'   => 'def',
+				'TABLE_SCHEMA'    => 'database',
+				'TABLE_NAME'      => 'wp_options',
+				'TABLE_TYPE'      => 'BASE TABLE',
+				'ENGINE'          => 'InnoDB',
+				'ROW_FORMAT'      => 'Dynamic',
 				'TABLE_COLLATION' => 'utf8mb4_general_ci',
-				'TABLE_COMMENT' => '',
-				'CREATE_TABLE' => 'CREATE TABLE "wp_options"(
+				'TABLE_COMMENT'   => '',
+				'CREATE_TABLE'    => 'CREATE TABLE "wp_options"(
 	"option_id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
   "option_name" text NOT NULL DEFAULT \'\' COLLATE NOCASE,
   "option_value" text NOT NULL COLLATE NOCASE,
   "autoload" text NOT NULL DEFAULT \'yes\' COLLATE NOCASE
 )',
-				'AUTO_INCREMENT' => null,
-				'CREATE_TIME' => null,
-				'UPDATE_TIME' => null,
-				'CHECK_TIME' => null,
-				'TABLE_ROWS' => '0',
-				'DATA_LENGTH' => '0',
-				'INDEX_LENGTH' => '0',
-				'DATA_FREE' => '0',
-				'VERSION' => '10',
+				'AUTO_INCREMENT'  => null,
+				'CREATE_TIME'     => null,
+				'UPDATE_TIME'     => null,
+				'CHECK_TIME'      => null,
+				'TABLE_ROWS'      => '0',
+				'AVG_ROW_LENGTH'  => '0',
+				'DATA_LENGTH'     => '0',
+				'MAX_DATA_LENGTH' => '0',
+				'INDEX_LENGTH'    => '0',
+				'DATA_FREE'       => '0',
+				'CHECKSUM'        => null,
+				'CREATE_OPTIONS'  => '',
+				'VERSION'         => '10',
 			),
 			(array) $result[0]
 		);
 
-		$result = $this->assertQuery( "SELECT
+		$result = $this->assertQuery(
+			"SELECT
 				table_name as 'name',
 				engine AS 'engine',
 				round( ( data_length / 1024 / 1024 ), 2 ) 'data'
@@ -113,9 +120,9 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 
 		$this->assertEquals(
 			array(
-				'name' => 'wp_posts',
+				'name'   => 'wp_posts',
 				'engine' => 'InnoDB',
-				'data' => '0',
+				'data'   => '0',
 			),
 			(array) $result[0]
 		);

--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -112,7 +112,7 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 			"SELECT
 				table_name as 'name',
 				engine AS 'engine',
-				round( ( data_length / 1024 / 1024 ), 2 ) 'data'
+				FLOOR( data_length / 1024 / 1024 ) 'data'
 			FROM INFORMATION_SCHEMA.TABLES
 			WHERE TABLE_NAME = 'wp_posts'
 			ORDER BY name ASC;"

--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -74,21 +74,21 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 	}
 
 	public function testInformationSchemaTables() {
-		$result = $this->assertQuery( "SELECT * FROM information_schema.tables" );
+		$result = $this->assertQuery( "SELECT * FROM information_schema.tables WHERE TABLE_NAME = 'wp_options'" );
 		$this->assertEquals(
 			array(
-				'TABLE_NAME' => '_mysql_data_types_cache',
+				'TABLE_NAME' => 'wp_options',
 				'TABLE_TYPE' => 'BASE TABLE',
 				'TABLE_SCHEMA' => 'database',
 				'ENGINE' => 'InnoDB',
 				'TABLE_COLLATION' => 'utf8mb4_general_ci',
 				'TABLE_COMMENT' => '',
-				'CREATE_TABLE' => 'CREATE TABLE _mysql_data_types_cache (
-		`table` TEXT NOT NULL,
-		`column_or_index` TEXT NOT NULL,
-		`mysql_type` TEXT NOT NULL,
-		PRIMARY KEY(`table`, `column_or_index`)
-	)',
+				'CREATE_TABLE' => 'CREATE TABLE "wp_options"(
+	"option_id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  "option_name" text NOT NULL DEFAULT \'\' COLLATE NOCASE,
+  "option_value" text NOT NULL COLLATE NOCASE,
+  "autoload" text NOT NULL DEFAULT \'yes\' COLLATE NOCASE
+)',
 				'AUTO_INCREMENT' => null,
 				'CREATE_TIME' => null,
 				'UPDATE_TIME' => null,

--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -84,13 +84,6 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 				'ENGINE'          => 'InnoDB',
 				'ROW_FORMAT'      => 'Dynamic',
 				'TABLE_COLLATION' => 'utf8mb4_general_ci',
-				'TABLE_COMMENT'   => '',
-				'CREATE_TABLE'    => 'CREATE TABLE "wp_options"(
-	"option_id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  "option_name" text NOT NULL DEFAULT \'\' COLLATE NOCASE,
-  "option_value" text NOT NULL COLLATE NOCASE,
-  "autoload" text NOT NULL DEFAULT \'yes\' COLLATE NOCASE
-)',
 				'AUTO_INCREMENT'  => null,
 				'CREATE_TIME'     => null,
 				'UPDATE_TIME'     => null,
@@ -104,6 +97,7 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 				'CHECKSUM'        => null,
 				'CREATE_OPTIONS'  => '',
 				'VERSION'         => '10',
+				'TABLE_COMMENT'   => '',
 			),
 			(array) $result[0]
 		);

--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -101,6 +101,38 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 			),
 			(array) $result[0]
 		);
+
+		$result = $this->assertQuery( "SELECT
+				table_name as 'name',
+				engine AS 'engine',
+				round( ( data_length / 1024 / 1024 ), 2 ) 'data'
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE TABLE_NAME = 'wp_posts'
+			ORDER BY name ASC;"
+		);
+
+		$this->assertEquals(
+			array(
+				'name' => 'wp_posts',
+				'engine' => 'InnoDB',
+				'data' => '0',
+			),
+			(array) $result[0]
+		);
+	}
+
+	public function testInformationSchemaQueryHidesSqliteSystemTables() {
+		/**
+		 * By default, system tables are not returned.
+		 */
+		$result = $this->assertQuery( "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sqlite_sequence'" );
+		$this->assertEquals( 0, count( $result ) );
+
+		/**
+		 * If we use a custom name for the table_name column, system tables are returned.
+		 */
+		$result = $this->assertQuery( "SELECT TABLE_NAME as custom_name FROM INFORMATION_SCHEMA.TABLES WHERE custom_name = 'sqlite_sequence'" );
+		$this->assertEquals( 1, count( $result ) );
 	}
 
 	private function assertQuery( $sql, $error_substring = null ) {

--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -73,6 +73,36 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 		self::assertIsNumeric( $count );
 	}
 
+	public function testInformationSchemaTables() {
+		$result = $this->assertQuery( "SELECT * FROM information_schema.tables" );
+		$this->assertEquals(
+			array(
+				'TABLE_NAME' => '_mysql_data_types_cache',
+				'TABLE_TYPE' => 'BASE TABLE',
+				'TABLE_SCHEMA' => 'database',
+				'ENGINE' => 'InnoDB',
+				'TABLE_COLLATION' => 'utf8mb4_general_ci',
+				'TABLE_COMMENT' => '',
+				'CREATE_TABLE' => 'CREATE TABLE _mysql_data_types_cache (
+		`table` TEXT NOT NULL,
+		`column_or_index` TEXT NOT NULL,
+		`mysql_type` TEXT NOT NULL,
+		PRIMARY KEY(`table`, `column_or_index`)
+	)',
+				'AUTO_INCREMENT' => null,
+				'CREATE_TIME' => null,
+				'UPDATE_TIME' => null,
+				'CHECK_TIME' => null,
+				'TABLE_ROWS' => '0',
+				'DATA_LENGTH' => '0',
+				'INDEX_LENGTH' => '0',
+				'DATA_FREE' => '0',
+				'VERSION' => '10',
+			),
+			(array) $result[0]
+		);
+	}
+
 	private function assertQuery( $sql, $error_substring = null ) {
 		$retval = $this->engine->query( $sql );
 		if ( null === $error_substring ) {

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1509,29 +1509,35 @@ class WP_SQLite_Translator {
 
 		if ( $table_name && str_starts_with( strtolower( $table_name ), 'information_schema' ) ) {
 			$this->is_information_schema_query = true;
-			$updated_query = preg_replace(
-				'/'.$table_name.'\.tables/i',
+			$updated_query                     = preg_replace(
+				'/' . $table_name . '\.tables/i',
 				"(SELECT
-					name as TABLE_NAME,
+					'def' as TABLE_CATALOG,           /* Standard value for TABLE_CATALOG */
 					'database' as TABLE_SCHEMA,
+					name as TABLE_NAME,
 					CASE type
 					WHEN 'table' THEN 'BASE TABLE'
 					WHEN 'view' THEN 'VIEW'
 					ELSE type
 					END as TABLE_TYPE,
 					'InnoDB' as ENGINE,
-					'utf8mb4_general_ci' as TABLE_COLLATION,
-					'' as TABLE_COMMENT,
-					sql as CREATE_TABLE,
+					'Dynamic' as ROW_FORMAT,          /* Standard InnoDB row format */
+					0 as TABLE_ROWS,
+					0 as AVG_ROW_LENGTH,
+					0 as DATA_LENGTH,
+					0 as MAX_DATA_LENGTH,
+					0 as INDEX_LENGTH,
+					0 as DATA_FREE,
 					NULL as AUTO_INCREMENT,
 					NULL as CREATE_TIME,
 					NULL as UPDATE_TIME,
 					NULL as CHECK_TIME,
-					0 as TABLE_ROWS,
-					0 as DATA_LENGTH,
-					0 as INDEX_LENGTH,
-					0 as DATA_FREE,
-					10 as VERSION
+					'utf8mb4_general_ci' as TABLE_COLLATION,
+					NULL as CHECKSUM,
+					'' as CREATE_OPTIONS,
+					'' as TABLE_COMMENT,
+					10 as VERSION,
+					sql as CREATE_TABLE
 					FROM sqlite_master
 					WHERE type IN ('table', 'view'))",
 				$updated_query
@@ -2805,7 +2811,7 @@ class WP_SQLite_Translator {
 					 * for the name/table_name column, the table would be removed.
 					 */
 					$table_name = true;
-					$table = (array) $table;
+					$table      = (array) $table;
 					if ( isset( $table['Name'] ) ) {
 						$table_name = $table['Name'];
 					} elseif ( isset( $table['table_name'] ) ) {
@@ -3536,24 +3542,32 @@ class WP_SQLite_Translator {
 				$database_expression = $this->rewriter->skip();
 				$stmt                = $this->execute_sqlite_query(
 					"SELECT
-						name as `Name`,
-						'myisam' as `Engine`,
-						10 as `Version`,
-						'Fixed' as `Row_format`,
-						0 as `Rows`,
-						0 as `Avg_row_length`,
-						0 as `Data_length`,
-						0 as `Max_data_length`,
-						0 as `Index_length`,
-						0 as `Data_free` ,
-						0 as `Auto_increment`,
-						'2024-03-20 15:33:20' as `Create_time`,
-						'2024-03-20 15:33:20' as `Update_time`,
-						null as `Check_time`,
-						null as `Collation`,
-						null as `Checksum`,
-						'' as `Create_options`,
-						'' as `Comment`
+						'def' as TABLE_CATALOG,           /* Standard value for TABLE_CATALOG */
+						'database' as TABLE_SCHEMA,
+						name as TABLE_NAME,
+						CASE type
+						WHEN 'table' THEN 'BASE TABLE'
+						WHEN 'view' THEN 'VIEW'
+						ELSE type
+						END as TABLE_TYPE,
+						'InnoDB' as ENGINE,
+						'Dynamic' as ROW_FORMAT,          /* Standard InnoDB row format */
+						0 as TABLE_ROWS,
+						0 as AVG_ROW_LENGTH,             /* Added missing column */
+						0 as DATA_LENGTH,
+						0 as MAX_DATA_LENGTH,            /* Added missing column */
+						0 as INDEX_LENGTH,
+						0 as DATA_FREE,
+						NULL as AUTO_INCREMENT,
+						NULL as CREATE_TIME,
+						NULL as UPDATE_TIME,
+						NULL as CHECK_TIME,
+						'utf8mb4_general_ci' as TABLE_COLLATION,
+						NULL as CHECKSUM,                /* Added missing column */
+						'' as CREATE_OPTIONS,            /* Added missing column */
+						'' as TABLE_COMMENT,
+						10 as VERSION,
+						sql as CREATE_TABLE
 					FROM sqlite_master
 					WHERE
 						type='table'

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2808,8 +2808,9 @@ class WP_SQLite_Translator {
 				$tables,
 				function ( $table ) {
 					/**
-					 * By default, we assume the table name is in the result set.
-					 * Otherwise, if a information_schema table uses a custom name
+					 * By default, we assume the table name is in the result set,
+					 * so we allow empty table names to pass through.
+					 * Otherwise, if an information_schema table uses a custom name
 					 * for the name/table_name column, the table would be removed.
 					 */
 					$table_name = '';
@@ -2821,7 +2822,7 @@ class WP_SQLite_Translator {
 					} elseif ( isset( $table['TABLE_NAME'] ) ) {
 						$table_name = $table['TABLE_NAME'];
 					}
-					return ! array_key_exists( $table_name, $this->sqlite_system_tables );
+					return '' === $table_name || ! array_key_exists( $table_name, $this->sqlite_system_tables );
 				},
 				ARRAY_FILTER_USE_BOTH
 			)

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1512,7 +1512,7 @@ class WP_SQLite_Translator {
 			$updated_query                     = preg_replace(
 				'/' . $table_name . '\.tables/i',
 				"(SELECT
-					'def' as TABLE_CATALOG,           /* Standard value for TABLE_CATALOG */
+					'def' as TABLE_CATALOG,
 					'database' as TABLE_SCHEMA,
 					name as TABLE_NAME,
 					CASE type
@@ -1521,7 +1521,7 @@ class WP_SQLite_Translator {
 					ELSE type
 					END as TABLE_TYPE,
 					'InnoDB' as ENGINE,
-					'Dynamic' as ROW_FORMAT,          /* Standard InnoDB row format */
+					'Dynamic' as ROW_FORMAT,
 					0 as TABLE_ROWS,
 					0 as AVG_ROW_LENGTH,
 					0 as DATA_LENGTH,
@@ -3542,32 +3542,24 @@ class WP_SQLite_Translator {
 				$database_expression = $this->rewriter->skip();
 				$stmt                = $this->execute_sqlite_query(
 					"SELECT
-						'def' as TABLE_CATALOG,           /* Standard value for TABLE_CATALOG */
-						'database' as TABLE_SCHEMA,
-						name as TABLE_NAME,
-						CASE type
-						WHEN 'table' THEN 'BASE TABLE'
-						WHEN 'view' THEN 'VIEW'
-						ELSE type
-						END as TABLE_TYPE,
-						'InnoDB' as ENGINE,
-						'Dynamic' as ROW_FORMAT,          /* Standard InnoDB row format */
-						0 as TABLE_ROWS,
-						0 as AVG_ROW_LENGTH,             /* Added missing column */
-						0 as DATA_LENGTH,
-						0 as MAX_DATA_LENGTH,            /* Added missing column */
-						0 as INDEX_LENGTH,
-						0 as DATA_FREE,
-						NULL as AUTO_INCREMENT,
-						NULL as CREATE_TIME,
-						NULL as UPDATE_TIME,
-						NULL as CHECK_TIME,
-						'utf8mb4_general_ci' as TABLE_COLLATION,
-						NULL as CHECKSUM,                /* Added missing column */
-						'' as CREATE_OPTIONS,            /* Added missing column */
-						'' as TABLE_COMMENT,
-						10 as VERSION,
-						sql as CREATE_TABLE
+						name as `Name`,
+						'myisam' as `Engine`,
+						10 as `Version`,
+						'Fixed' as `Row_format`,
+						0 as `Rows`,
+						0 as `Avg_row_length`,
+						0 as `Data_length`,
+						0 as `Max_data_length`,
+						0 as `Index_length`,
+						0 as `Data_free` ,
+						0 as `Auto_increment`,
+						'2024-03-20 15:33:20' as `Create_time`,
+						'2024-03-20 15:33:20' as `Update_time`,
+						null as `Check_time`,
+						null as `Collation`,
+						null as `Checksum`,
+						'' as `Create_options`,
+						'' as `Comment`
 					FROM sqlite_master
 					WHERE
 						type='table'

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1538,7 +1538,6 @@ class WP_SQLite_Translator {
 					WHERE type IN ('table', 'view'))",
 				$updated_query
 			);
-			var_dump( $updated_query );
 		} elseif (
 			// Examples: @@SESSION.sql_mode, @@GLOBAL.max_allowed_packet, @@character_set_client
 			preg_match( '/@@((SESSION|GLOBAL)\s*\.\s*)?\w+\b/i', $updated_query ) === 1 ||

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1511,6 +1511,9 @@ class WP_SQLite_Translator {
 			$this->is_information_schema_query = true;
 			$updated_query                     = preg_replace(
 				'/' . $table_name . '\.tables/i',
+				/**
+				 * TODO: Return real values for hardcoded column values.
+				 */
 				"(SELECT
 					'def' as TABLE_CATALOG,
 					'database' as TABLE_SCHEMA,

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2810,7 +2810,7 @@ class WP_SQLite_Translator {
 					 * Otherwise, if a information_schema table uses a custom name
 					 * for the name/table_name column, the table would be removed.
 					 */
-					$table_name = true;
+					$table_name = '';
 					$table      = (array) $table;
 					if ( isset( $table['Name'] ) ) {
 						$table_name = $table['Name'];
@@ -2819,7 +2819,7 @@ class WP_SQLite_Translator {
 					} elseif ( isset( $table['TABLE_NAME'] ) ) {
 						$table_name = $table['TABLE_NAME'];
 					}
-					return $table_name && ! array_key_exists( $table_name, $this->sqlite_system_tables );
+					return ! array_key_exists( $table_name, $this->sqlite_system_tables );
 				},
 				ARRAY_FILTER_USE_BOTH
 			)

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1521,6 +1521,7 @@ class WP_SQLite_Translator {
 					ELSE type
 					END as TABLE_TYPE,
 					'InnoDB' as ENGINE,
+					10 as VERSION,
 					'Dynamic' as ROW_FORMAT,
 					0 as TABLE_ROWS,
 					0 as AVG_ROW_LENGTH,
@@ -1535,9 +1536,7 @@ class WP_SQLite_Translator {
 					'utf8mb4_general_ci' as TABLE_COLLATION,
 					NULL as CHECKSUM,
 					'' as CREATE_OPTIONS,
-					'' as TABLE_COMMENT,
-					10 as VERSION,
-					sql as CREATE_TABLE
+					'' as TABLE_COMMENT
 					FROM sqlite_master
 					WHERE type IN ('table', 'view'))",
 				$updated_query


### PR DESCRIPTION
Before this PR information schema queries always executed hardcoded queries, which made it impossible to use WHERE, ORDER, and AS in information schema queries.

This PR adds support for executing information schema queries instead of running hardcoded queries defined by this plugin. This means we can use WHERE, ORDER, AS, and other select query clauses. 

Thanks @ashfame for working with me on this PR!

## Testing 

- CI  