### PR TITLE
Fix undefined method call

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -341,7 +341,7 @@ class WP_SQLite_DB extends wpdb {
 			if ( $this->dbh instanceof WP_SQLite_Driver ) {
 				$this->rows_affected = $this->dbh->get_last_return_value();
 			} else {
-				$this->rows_affected = $this->dbh->get_rows_affected();
+				$this->rows_affected = $this->dbh->get_affected_rows();
 			}
 
 			// Take note of the insert_id.


### PR DESCRIPTION
This was a small typo regression caused by https://github.com/Automattic/sqlite-database-integration/pull/1.

Playground links:
- The current `develop` branch with AST disabled: [Playground link](https://playground.wordpress.net/builder/builder.html#{%22landingPage%22:%22/wp-admin/%22,%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy/?repo=Automattic/sqlite-database-integration&branch=develop%22},%22options%22:{%22activate%22:false}},{%22step%22:%22rmdir%22,%22path%22:%22/internal/shared/sqlite-database-integration%22},{%22step%22:%22mv%22,%22fromPath%22:%22/wordpress/wp-content/plugins/sqlite-database-integration-develop%22,%22toPath%22:%22/internal/shared/sqlite-database-integration%22}],%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%226.7%22},%22features%22:{%22networking%22:true},%22login%22:true}) (failing)
- This fix: [Playground link](https://playground.wordpress.net/builder/builder.html#{%22landingPage%22:%22/wp-admin/%22,%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy/?repo=Automattic/sqlite-database-integration&branch=fix-undefined-method-crash%22},%22options%22:{%22activate%22:false}},{%22step%22:%22rmdir%22,%22path%22:%22/internal/shared/sqlite-database-integration%22},{%22step%22:%22mv%22,%22fromPath%22:%22/wordpress/wp-content/plugins/sqlite-database-integration-fix-undefined-method-crash%22,%22toPath%22:%22/internal/shared/sqlite-database-integration%22}],%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%226.7%22},%22features%22:{%22networking%22:true},%22login%22:true}) (fixed)

Fixes https://github.com/Automattic/sqlite-database-integration/issues/19.