### PR TITLE
Temporary table support

### DIFF
--- a/.github/workflows/wp-tests-phpunit-run.js
+++ b/.github/workflows/wp-tests-phpunit-run.js
@@ -47,9 +47,6 @@ const expectedErrors = [
 const expectedFailures = [
 	'Tests_Comment::test_wp_new_comment_respects_comment_field_lengths',
 	'Tests_Comment::test_wp_update_comment',
-	'Tests_DB_dbDelta::test_column_type_change_with_hyphens_in_name',
-	'Tests_DB_dbDelta::test_query_with_backticks_does_not_cause_a_query_to_alter_all_columns_and_indices_to_run_even_if_none_have_changed',
-	'Tests_DB_dbDelta::test_query_with_backticks_does_not_throw_an_undefined_index_warning',
 	'Tests_DB_dbDelta::test_spatial_indices',
 	'Tests_DB::test_charset_switched_to_utf8mb4',
 	'Tests_DB::test_close',

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -3079,6 +3079,20 @@ QUERY
 		);
 	}
 
+	public function testCreateTemporaryTableIfNotExists(): void {
+		$this->assertQuery(
+			'CREATE TEMPORARY TABLE t (ID INTEGER, name TEXT)'
+		);
+		$this->assertQuery(
+			'CREATE TEMPORARY TABLE IF NOT EXISTS t (ID INTEGER, name TEXT)'
+		);
+
+		$this->expectExceptionMessage( 'table `t` already exists' );
+		$this->assertQuery(
+			'CREATE TEMPORARY TABLE t (ID INTEGER, name TEXT)'
+		);
+	}
+
 	public function testTranslatesComplexDelete() {
 		$this->sqlite->query(
 			"CREATE TABLE wptests_dummy (

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -3976,4 +3976,54 @@ QUERY
 			array( 'TRUNCATE tables' ),
 		);
 	}
+
+	public function testTemporaryTableHasPriorityOverStandardTable(): void {
+		// Create a standard and a temporary table with the same name.
+		$this->assertQuery( 'CREATE TABLE t (a INT, INDEX ia(a))' );
+		$this->assertQuery( 'CREATE TEMPORARY TABLE t (b INT, INDEX ib(b))' );
+
+		// SHOW CREATE TABLE will show the temporary table.
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertEquals(
+			"CREATE TEMPORARY TABLE `t` (\n"
+				. "  `b` int DEFAULT NULL,\n"
+				. "  KEY `ib` (`b`)\n"
+				. ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+			$result[0]->{'Create Table'}
+		);
+
+		// SHOW COLUMNS FROM will show the temporary table.
+		$result = $this->assertQuery( 'SHOW COLUMNS FROM t' );
+		$this->assertEquals( 'b', $result[0]->Field );
+
+		// DESCRIBE will show the temporary table.
+		$result = $this->assertQuery( 'DESCRIBE t' );
+		$this->assertEquals( 'b', $result[0]->Field );
+
+		// SHOW INDEXES FROM will show the temporary table.
+		$result = $this->assertQuery( 'SHOW INDEXES FROM t' );
+		$this->assertEquals( 'ib', $result[0]->Key_name );
+
+		// ALTER TABLE will use the temporary table.
+		$this->assertQuery( 'ALTER TABLE t ADD COLUMN c INT' );
+		$result = $this->assertQuery( 'SHOW COLUMNS FROM t' );
+		$this->assertEquals( 'b', $result[0]->Field );
+		$this->assertEquals( 'c', $result[1]->Field );
+
+		// The temporary table doesn't show up in information schema.
+		$result = $this->assertQuery( 'SELECT * FROM information_schema.columns WHERE table_name = "t"' );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'a', $result[0]->COLUMN_NAME );
+
+		// First DROP TABLE removes the temporary table.
+		$this->assertQuery( 'DROP TABLE t' );
+		$result = $this->assertQuery( 'SHOW COLUMNS FROM t' );
+		$this->assertEquals( 'a', $result[0]->Field );
+
+		// Second DROP TABLE removes the standard table.
+		$this->expectException( WP_SQLite_Driver_Exception::class );
+		$this->expectExceptionMessage( "Table 'wp.t' doesn't exist" );
+		$this->assertQuery( 'DROP TABLE t' );
+		$result = $this->assertQuery( 'SHOW COLUMNS FROM t' );
+	}
 }

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -480,7 +480,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		);
 	}
 
-	public function testCreateTableFromSelectQuery(): void {
+	// @TODO: Implement information schema support for CREATE TABLE ... AS SELECT.
+	/*public function testCreateTableFromSelectQuery(): void {
 		// CREATE TABLE AS SELECT ...
 		$this->assertQuery(
 			'CREATE TABLE `t1` AS SELECT * FROM `t2` STRICT',
@@ -493,7 +494,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'CREATE TABLE `t1` AS SELECT * FROM `t2` STRICT',
 			'CREATE TABLE t1 SELECT * FROM t2'
 		);
-	}
+	}*/
 
 	// TODO: IF NOT EXISTS
 	/*public function testCreateTemporaryTable(): void {

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -401,23 +401,6 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		);
 	}
 
-	// @TODO: IF NOT EXISTS
-	/*public function testCreateTableWithIfNotExists(): void {
-		$this->assertQuery(
-			'CREATE TABLE IF NOT EXISTS "t" ( "id" INTEGER ) STRICT',
-			'CREATE TABLE IF NOT EXISTS t (id INT)'
-		);
-
-		$this->assertExecutedInformationSchemaQueries(
-			array(
-				'INSERT INTO _wp_sqlite_mysql_information_schema_tables (table_schema, table_name, table_type, engine, row_format, table_collation)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
-				'INSERT INTO _wp_sqlite_mysql_information_schema_columns (table_schema, table_name, column_name, ordinal_position, column_default, is_nullable, data_type, character_maximum_length, character_octet_length, numeric_precision, numeric_scale, datetime_precision, character_set_name, collation_name, column_type, column_key, extra, privileges, column_comment, generation_expression, srs_id)'
-					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', '', 'select,insert,update,references', '', '', null)",
-			)
-		);
-	}*/
-
 	public function testCreateTableWithInlineUniqueIndexes(): void {
 		$this->assertQuery(
 			array(
@@ -496,19 +479,12 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		);
 	}*/
 
-	// TODO: IF NOT EXISTS
-	/*public function testCreateTemporaryTable(): void {
+	public function testCreateTemporaryTable(): void {
 		$this->assertQuery(
 			'CREATE TEMPORARY TABLE `t` ( `id` INTEGER ) STRICT',
 			'CREATE TEMPORARY TABLE t (id INT)'
 		);
-
-		// With IF NOT EXISTS.
-		$this->assertQuery(
-			'CREATE TEMPORARY TABLE IF NOT EXISTS `t` ( `id` INTEGER ) STRICT',
-			'CREATE TEMPORARY TABLE IF NOT EXISTS t (id INT)'
-		);
-	}*/
+	}
 
 	public function testDropTemporaryTable(): void {
 		// Create a temporary table first so DROP doesn't fail.

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -495,7 +495,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		);
 	}
 
-	public function testCreateTemporaryTable(): void {
+	// TODO: IF NOT EXISTS
+	/*public function testCreateTemporaryTable(): void {
 		$this->assertQuery(
 			'CREATE TEMPORARY TABLE `t` ( `id` INTEGER ) STRICT',
 			'CREATE TEMPORARY TABLE t (id INT)'
@@ -506,9 +507,12 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'CREATE TEMPORARY TABLE IF NOT EXISTS `t` ( `id` INTEGER ) STRICT',
 			'CREATE TEMPORARY TABLE IF NOT EXISTS t (id INT)'
 		);
-	}
+	}*/
 
 	public function testDropTemporaryTable(): void {
+		// Create a temporary table first so DROP doesn't fail.
+		$this->driver->query( 'CREATE TEMPORARY TABLE t (id INT)' );
+
 		$this->assertQuery(
 			'DROP TABLE `temp`.`t`',
 			'DROP TEMPORARY TABLE t'
@@ -1346,6 +1350,16 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		if ( count( $executed_queries ) > 2 ) {
 			$executed_queries = array_values( array_slice( $executed_queries, 1, -1, true ) );
 		}
+
+		// Remove temporary table existence checks.
+		$executed_queries = array_values(
+			array_filter(
+				$executed_queries,
+				function ( $query ) {
+					return "SELECT 1 FROM sqlite_temp_schema WHERE type = 'table' AND name = ?" !== $query;
+				}
+			)
+		);
 
 		// Remove "information_schema" queries.
 		$executed_queries = array_values(

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1086,14 +1086,22 @@ class WP_SQLite_Driver {
 	private function execute_create_table_statement( WP_Parser_Node $node ): void {
 		$subnode = $node->get_first_child_node();
 
-		// Handle TEMPORARY and CREATE TABLE ... SELECT.
+		// Handle TEMPORARY keyword.
 		$table_is_temporary = $subnode->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
-		$element_list       = $subnode->get_first_child_node( 'tableElementList' );
+
+		// Handle CREATE TABLE ... [AS] SELECT.
+		$element_list = $subnode->get_first_child_node( 'tableElementList' );
 		if ( null === $element_list ) {
-			$query = $this->translate( $node ) . ' STRICT';
-			$this->execute_sqlite_query( $query );
-			$this->set_result_from_affected_rows();
-			return;
+			/*
+			 * While SQLite supports CREATE TABLE ... AS SELECT statements,
+			 * we need to somehow implement information schema support for
+			 * the tables created in this way.
+			 *
+			 * TODO: Implement information schema support for CREATE TABLE ... AS SELECT.
+			 */
+			throw $this->new_not_supported_exception(
+				'CREATE TABLE ... [AS] SELECT is currently not supported'
+			);
 		}
 
 		// Get table name.

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1087,9 +1087,9 @@ class WP_SQLite_Driver {
 		$subnode = $node->get_first_child_node();
 
 		// Handle TEMPORARY and CREATE TABLE ... SELECT.
-		$is_temporary = $subnode->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
-		$element_list = $subnode->get_first_child_node( 'tableElementList' );
-		if ( true === $is_temporary || null === $element_list ) {
+		$table_is_temporary = $subnode->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
+		$element_list       = $subnode->get_first_child_node( 'tableElementList' );
+		if ( null === $element_list ) {
 			$query = $this->translate( $node ) . ' STRICT';
 			$this->execute_sqlite_query( $query );
 			$this->set_result_from_affected_rows();
@@ -1103,7 +1103,7 @@ class WP_SQLite_Driver {
 
 		// Handle IF NOT EXISTS.
 		if ( $subnode->has_child_node( 'ifNotExists' ) ) {
-			$tables_table = $this->information_schema_builder->get_table_name( 'tables' );
+			$tables_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'tables' );
 			$table_exists = $this->execute_sqlite_query(
 				"SELECT 1 FROM $tables_table WHERE table_schema = ? AND table_name = ?",
 				array( $this->db_name, $table_name )
@@ -1119,7 +1119,7 @@ class WP_SQLite_Driver {
 		$this->information_schema_builder->record_create_table( $node );
 
 		// Generate CREATE TABLE statement from the information schema tables.
-		$queries            = $this->get_sqlite_create_table_statement( $table_name );
+		$queries            = $this->get_sqlite_create_table_statement( $table_is_temporary, $table_name );
 		$create_table_query = $queries[0];
 		$constraint_queries = array_slice( $queries, 1 );
 
@@ -1141,8 +1141,10 @@ class WP_SQLite_Driver {
 			$this->translate( $node->get_first_descendant_node( 'tableRef' ) )
 		);
 
+		$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
+
 		// Save all column names from the original table.
-		$columns_table = $this->information_schema_builder->get_table_name( 'columns' );
+		$columns_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
 		$column_names  = $this->execute_sqlite_query(
 			"SELECT COLUMN_NAME FROM $columns_table WHERE table_schema = ? AND table_name = ?",
 			array( $this->db_name, $table_name )
@@ -1188,7 +1190,7 @@ class WP_SQLite_Driver {
 		}
 
 		$this->information_schema_builder->record_alter_table( $node );
-		$this->recreate_table_from_information_schema( $table_name, $column_map );
+		$this->recreate_table_from_information_schema( $table_is_temporary, $table_name, $column_map );
 
 		// @TODO: Consider using a "fast path" for ALTER TABLE statements that
 		//        consist only of operations that SQLite's ALTER TABLE supports.
@@ -1201,13 +1203,15 @@ class WP_SQLite_Driver {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_drop_table_statement( WP_Parser_Node $node ): void {
-		$child_node = $node->get_first_child_node();
+		// Record the changes in the information schema.
+		$this->information_schema_builder->record_drop_table( $node );
 
 		// MySQL supports removing multiple tables in a single query DROP query.
 		// In SQLite, we need to execute each DROP TABLE statement separately.
-		$table_refs   = $child_node->get_first_child_node( 'tableRefList' )->get_child_nodes();
-		$is_temporary = $child_node->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
-		$queries      = array();
+		$child_node         = $node->get_first_child_node();
+		$table_refs         = $child_node->get_first_child_node( 'tableRefList' )->get_child_nodes();
+		$table_is_temporary = $child_node->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
+		$queries            = array();
 		foreach ( $table_refs as $table_ref ) {
 			$parts = array();
 			foreach ( $child_node->get_children() as $child ) {
@@ -1221,7 +1225,7 @@ class WP_SQLite_Driver {
 				// Replace table list with the current table reference.
 				if ( ! $is_token && 'tableRefList' === $child->rule_name ) {
 					// Add a "temp." schema prefix for temporary tables.
-					$prefix = $is_temporary ? '`temp`.' : '';
+					$prefix = $table_is_temporary ? '`temp`.' : '';
 					$part   = $prefix . $this->translate( $table_ref );
 				} else {
 					$part = $this->translate( $child );
@@ -1237,7 +1241,6 @@ class WP_SQLite_Driver {
 		foreach ( $queries as $query ) {
 			$this->execute_sqlite_query( $query );
 		}
-		$this->information_schema_builder->record_drop_table( $node );
 	}
 
 	/**
@@ -1280,7 +1283,9 @@ class WP_SQLite_Driver {
 						$this->translate( $node->get_first_child_node( 'tableRef' ) )
 					);
 
-					$sql = $this->get_mysql_create_table_statement( $table_name );
+					$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
+
+					$sql = $this->get_mysql_create_table_statement( $table_is_temporary, $table_name );
 					if ( null === $sql ) {
 						$this->set_results_from_fetched_data( array() );
 					} else {
@@ -1341,6 +1346,8 @@ class WP_SQLite_Driver {
 		// TODO: FROM/IN (multiple)
 		// TODO: WHERE
 
+		$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
+
 		/*
 		 * TODO: Index naming.
 		 *
@@ -1359,7 +1366,7 @@ class WP_SQLite_Driver {
 		 *       $mysql_key_name = substr( $mysql_key_name, strlen( "{$table_name}__" ) );
 		 */
 
-		$statistics_table = $this->information_schema_builder->get_table_name( 'statistics' );
+		$statistics_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'statistics' );
 		$index_info       = $this->execute_sqlite_query(
 			'
 				SELECT
@@ -1416,7 +1423,10 @@ class WP_SQLite_Driver {
 		}
 
 		// Fetch table information.
-		$tables_tables = $this->information_schema_builder->get_table_name( 'tables' );
+		$tables_tables = $this->information_schema_builder->get_table_name(
+			false, // SHOW TABLE STATUS lists only non-temporary tables.
+			'tables'
+		);
 		$table_info    = $this->execute_sqlite_query(
 			sprintf(
 				"SELECT * FROM $tables_tables WHERE table_schema = ? %s",
@@ -1481,7 +1491,10 @@ class WP_SQLite_Driver {
 		}
 
 		// Fetch table information.
-		$table_tables = $this->information_schema_builder->get_table_name( 'tables' );
+		$table_tables = $this->information_schema_builder->get_table_name(
+			false, // SHOW TABLES lists only non-temporary tables.
+			'tables'
+		);
 		$table_info   = $this->execute_sqlite_query(
 			sprintf(
 				"SELECT * FROM $table_tables WHERE table_schema = ? %s",
@@ -1536,8 +1549,10 @@ class WP_SQLite_Driver {
 			);
 		}
 
+		$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
+
 		// Check if the table exists.
-		$tables_tables = $this->information_schema_builder->get_table_name( 'tables' );
+		$tables_tables = $this->information_schema_builder->get_table_name( $table_is_temporary, 'tables' );
 		$table_exists  = $this->execute_sqlite_query(
 			"SELECT 1 FROM $tables_tables WHERE table_schema = ? AND table_name = ?",
 			array( $this->db_name, $table_name )
@@ -1560,7 +1575,7 @@ class WP_SQLite_Driver {
 		$column_info = $this->execute_sqlite_query(
 			sprintf(
 				'SELECT * FROM %s WHERE table_schema = ? AND table_name = ? %s',
-				$this->information_schema_builder->get_table_name( 'columns' ),
+				$this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' ),
 				$condition ?? ''
 			),
 			array( $database, $table_name )
@@ -1598,7 +1613,9 @@ class WP_SQLite_Driver {
 			$this->translate( $node->get_first_child_node( 'tableRef' ) )
 		);
 
-		$columns_table = $this->information_schema_builder->get_table_name( 'columns' );
+		$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
+
+		$columns_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
 		$column_info   = $this->execute_sqlite_query(
 			"
 				SELECT
@@ -1684,7 +1701,8 @@ class WP_SQLite_Driver {
 						 * This corresponds to older MySQL OPTIMIZE TABLE behavior
 						 * and still applies to some storage engines in some cases.
 						 */
-						$this->recreate_table_from_information_schema( $table_name );
+						$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
+						$this->recreate_table_from_information_schema( $table_is_temporary, $table_name );
 						$errors = array();
 						break;
 					default:
@@ -2121,7 +2139,7 @@ class WP_SQLite_Driver {
 				$object_name = $this->unquote_sqlite_identifier(
 					$this->translate_sequence( $object_node->get_children() )
 				);
-				$parts[]     = $this->information_schema_builder->get_table_name( $object_name );
+				$parts[]     = $this->information_schema_builder->get_table_name( false, $object_name );
 			} else {
 				$quoted_object_name = $this->translate( $object_node );
 				$object_name        = $this->unquote_sqlite_identifier( $quoted_object_name );
@@ -2454,15 +2472,20 @@ class WP_SQLite_Driver {
 	 * See:
 	 *   https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes
 	 *
-	 * @param  string $table_name The name of the table to recreate.
-	 * @param  array  $column_map Optional. A map of column names (old name -> new name)
-	 *                            to use when copying data from the original table.
-	 *                            When not provided, all columns are copied without renaming.
+	 * @param  bool   $table_is_temporary Whether the table is temporary.
+	 * @param  string $table_name         The name of the table to recreate.
+	 * @param  array  $column_map         Optional. A map of column names (old name -> new name)
+	 *                                    to use when copying data from the original table.
+	 *                                    When not provided, all columns are copied without renaming.
 	 * @throws WP_SQLite_Driver_Exception
 	 */
-	private function recreate_table_from_information_schema( string $table_name, array $column_map = null ): void {
+	private function recreate_table_from_information_schema(
+		bool $table_is_temporary,
+		string $table_name,
+		array $column_map = null
+	): void {
 		if ( null === $column_map ) {
-			$columns_table = $this->information_schema_builder->get_table_name( 'columns' );
+			$columns_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
 			$column_names  = $this->execute_sqlite_query(
 				"SELECT COLUMN_NAME FROM $columns_table WHERE table_schema = ? AND table_name = ?",
 				array( $this->db_name, $table_name )
@@ -2488,7 +2511,7 @@ class WP_SQLite_Driver {
 		$tmp_table_name        = self::RESERVED_PREFIX . "tmp_{$table_name}_" . uniqid();
 		$quoted_table_name     = $this->quote_sqlite_identifier( $table_name );
 		$quoted_tmp_table_name = $this->quote_sqlite_identifier( $tmp_table_name );
-		$queries               = $this->get_sqlite_create_table_statement( $table_name, $tmp_table_name );
+		$queries               = $this->get_sqlite_create_table_statement( $table_is_temporary, $table_name, $tmp_table_name );
 		$create_table_query    = $queries[0];
 		$constraint_queries    = array_slice( $queries, 1 );
 		$this->execute_sqlite_query( $create_table_query );
@@ -2567,14 +2590,19 @@ class WP_SQLite_Driver {
 	/**
 	 * Generate a SQLite CREATE TABLE statement from information schema data.
 	 *
-	 * @param  string      $table_name     The name of the table to create.
-	 * @param  string|null $new_table_name Override the original table name for ALTER TABLE emulation.
-	 * @return string[]                    Queries to create the table, indexes, and constraints.
-	 * @throws WP_SQLite_Driver_Exception  When the table information is missing.
+	 * @param  bool        $table_is_temporary Whether the table is temporary.
+	 * @param  string      $table_name         The name of the table to create.
+	 * @param  string|null $new_table_name     Override the original table name for ALTER TABLE emulation.
+	 * @return string[]                        Queries to create the table, indexes, and constraints.
+	 * @throws WP_SQLite_Driver_Exception      When the table information is missing.
 	 */
-	private function get_sqlite_create_table_statement( string $table_name, ?string $new_table_name = null ): array {
+	private function get_sqlite_create_table_statement(
+		bool $table_is_temporary = false,
+		string $table_name,
+		?string $new_table_name = null
+	): array {
 		// 1. Get table info.
-		$tables_table = $this->information_schema_builder->get_table_name( 'tables' );
+		$tables_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'tables' );
 		$table_info   = $this->execute_sqlite_query(
 			"
 				SELECT *
@@ -2594,14 +2622,14 @@ class WP_SQLite_Driver {
 		}
 
 		// 2. Get column info.
-		$columns_table = $this->information_schema_builder->get_table_name( 'columns' );
+		$columns_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
 		$column_info   = $this->execute_sqlite_query(
 			"SELECT * FROM $columns_table WHERE table_schema = ? AND table_name = ?",
 			array( $this->db_name, $table_name )
 		)->fetchAll( PDO::FETCH_ASSOC );
 
 		// 3. Get index info, grouped by index name.
-		$statistics_table = $this->information_schema_builder->get_table_name( 'statistics' );
+		$statistics_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'statistics' );
 		$constraint_info  = $this->execute_sqlite_query(
 			"SELECT * FROM $statistics_table WHERE table_schema = ? AND table_name = ?",
 			array( $this->db_name, $table_name )
@@ -2746,7 +2774,8 @@ class WP_SQLite_Driver {
 
 		// 6. Compose the CREATE TABLE statement.
 		$create_table_query  = sprintf(
-			"CREATE TABLE %s (\n",
+			"CREATE %sTABLE %s (\n",
+			$table_is_temporary ? 'TEMPORARY ' : '',
 			$this->quote_sqlite_identifier( $new_table_name ?? $table_name )
 		);
 		$create_table_query .= implode( ",\n", $rows );
@@ -2757,12 +2786,13 @@ class WP_SQLite_Driver {
 	/**
 	 * Generate a MySQL CREATE TABLE statement from information schema data.
 	 *
-	 * @param  string $table_name The name of the table to create.
-	 * @return string             The CREATE TABLE statement.
+	 * @param  bool   $table_is_temporary Whether the table is temporary.
+	 * @param  string $table_name         The name of the table to create.
+	 * @return string                     The CREATE TABLE statement.
 	 */
-	private function get_mysql_create_table_statement( string $table_name ): ?string {
+	private function get_mysql_create_table_statement( bool $table_is_temporary, string $table_name ): ?string {
 		// 1. Get table info.
-		$tables_table = $this->information_schema_builder->get_table_name( 'tables' );
+		$tables_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'tables' );
 		$table_info   = $this->execute_sqlite_query(
 			"
 				SELECT *
@@ -2779,14 +2809,14 @@ class WP_SQLite_Driver {
 		}
 
 		// 2. Get column info.
-		$columns_table = $this->information_schema_builder->get_table_name( 'columns' );
+		$columns_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
 		$column_info   = $this->execute_sqlite_query(
 			"SELECT * FROM $columns_table WHERE table_schema = ? AND table_name = ?",
 			array( $this->db_name, $table_name )
 		)->fetchAll( PDO::FETCH_ASSOC );
 
 		// 3. Get index info, grouped by index name.
-		$statistics_table = $this->information_schema_builder->get_table_name( 'statistics' );
+		$statistics_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'statistics' );
 		$constraint_info  = $this->execute_sqlite_query(
 			"SELECT * FROM $statistics_table WHERE table_schema = ? AND table_name = ?",
 			array( $this->db_name, $table_name )
@@ -2883,7 +2913,11 @@ class WP_SQLite_Driver {
 		$collation = $table_info['TABLE_COLLATION'];
 		$charset   = substr( $collation, 0, strpos( $collation, '_' ) );
 
-		$sql  = sprintf( "CREATE TABLE %s (\n", $this->quote_mysql_identifier( $table_name ) );
+		$sql  = sprintf(
+			"CREATE %sTABLE %s (\n",
+			$table_is_temporary ? 'TEMPORARY ' : '',
+			$this->quote_mysql_identifier( $table_name )
+		);
 		$sql .= implode( ",\n", $rows );
 		$sql .= "\n)";
 		$sql .= sprintf( ' ENGINE=%s', $table_info['ENGINE'] );

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1792,8 +1792,6 @@ class WP_SQLite_Driver {
 					return implode( ' ', $parts );
 				}
 				return $this->translate_sequence( $node->get_children() );
-			case 'schemaRef':
-				return $this->translate_schema_identifier( $node );
 			case 'qualifiedIdentifier':
 			case 'tableRefWithWildcard':
 				$parts = $node->get_descendant_nodes( 'identifier' );

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -337,6 +337,17 @@ class WP_SQLite_Information_Schema_Builder {
 	private $table_prefix;
 
 	/**
+	 * A prefix for information schema table names for temporary tables.
+	 *
+	 * This is needed because for temporary tables, we store the information
+	 * schema tables as temporary tables as well, and temporary tables with
+	 * the same name as regular tables would override the regular tables.
+	 *
+	 * @var string
+	 */
+	private $temporary_table_prefix;
+
+	/**
 	 * Query callback.
 	 *
 	 * @TODO: Consider extracting a part of the WP_SQLite_Driver class
@@ -354,19 +365,40 @@ class WP_SQLite_Information_Schema_Builder {
 	 * @param callable(string, array): PDOStatement $query_callback  A callback that executes an SQLite query.
 	 */
 	public function __construct( string $database, string $reserved_prefix, callable $query_callback ) {
-		$this->db_name        = $database;
-		$this->query_callback = $query_callback;
-		$this->table_prefix   = $reserved_prefix . 'mysql_information_schema_';
+		$this->db_name                = $database;
+		$this->query_callback         = $query_callback;
+		$this->table_prefix           = $reserved_prefix . 'mysql_information_schema_';
+		$this->temporary_table_prefix = $reserved_prefix . 'mysql_information_schema_tmp_';
 	}
 
 	/**
 	 * Get SQLite table name for the given MySQL information schema table name.
 	 *
-	 * @param  string $infromation_schema_table_name The MySQL information schema table name.
+	 * @param  bool   $table_is_temporary            Whether a temporary table information schema is requested.
+	 * @param  string $information_schema_table_name The MySQL information schema table name.
 	 * @return string                                The SQLite table name.
 	 */
-	public function get_table_name( string $infromation_schema_table_name ): string {
-		return $this->table_prefix . $infromation_schema_table_name;
+	public function get_table_name( bool $table_is_temporary, string $information_schema_table_name ): string {
+		$prefix = $table_is_temporary ? $this->temporary_table_prefix : $this->table_prefix;
+		return $prefix . $information_schema_table_name;
+	}
+
+	/**
+	 * Check if a temporary table exists in the SQLite database.
+	 *
+	 * @param  string $table_name The temporary table name.
+	 * @return bool               True if the temporary table exists, false otherwise.
+	 */
+	public function temporary_table_exists( string $table_name ): bool {
+		/*
+		 * We could search in the "{$this->temporary_table_prefix}tables" table,
+		 * but it may not exist yet, so using "sqlite_temp_schema" is simpler.
+		 */
+		$stmt = $this->query(
+			"SELECT 1 FROM sqlite_temp_schema WHERE type = 'table' AND name = ?",
+			array( $table_name )
+		);
+		return $stmt->fetchColumn() === '1';
 	}
 
 	/**
@@ -376,6 +408,17 @@ class WP_SQLite_Information_Schema_Builder {
 	public function ensure_information_schema_tables(): void {
 		foreach ( self::CREATE_INFORMATION_SCHEMA_QUERIES as $query ) {
 			$this->query( str_replace( '<prefix>', $this->table_prefix, $query ) );
+		}
+	}
+
+	/**
+	 * Ensure that the temporary information schema tables exist in
+	 * the SQLite database. Tables that are missing will be created.
+	 */
+	public function ensure_temporary_information_schema_tables(): void {
+		foreach ( self::CREATE_INFORMATION_SCHEMA_QUERIES as $query ) {
+			$query = str_replace( 'CREATE TABLE', 'CREATE TEMPORARY TABLE', $query );
+			$this->query( str_replace( '<prefix>', $this->temporary_table_prefix, $query ) );
 		}
 	}
 
@@ -390,9 +433,20 @@ class WP_SQLite_Information_Schema_Builder {
 		$table_row_format = 'MyISAM' === $table_engine ? 'Fixed' : 'Dynamic';
 		$table_collation  = $this->get_table_collation( $node );
 
+		/*
+		 * When creating a temporary table:
+		 *   1. Track that we're processing a temporary table.
+		 *   2. Ensure that the temporary information schema tables exist.
+		 */
+		$subnode            = $node->get_first_child_node();
+		$table_is_temporary = $subnode->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
+		if ( true === $table_is_temporary ) {
+			$this->ensure_temporary_information_schema_tables();
+		}
+
 		// 1. Table.
 		$this->insert_values(
-			'tables',
+			$this->get_table_name( $table_is_temporary, 'tables' ),
 			array(
 				'table_schema'    => $this->db_name,
 				'table_name'      => $table_name,
@@ -415,7 +469,10 @@ class WP_SQLite_Information_Schema_Builder {
 				$column_node,
 				$column_position
 			);
-			$this->insert_values( 'columns', $column_data );
+			$this->insert_values(
+				$this->get_table_name( $table_is_temporary, 'columns' ),
+				$column_data
+			);
 
 			// Inline column constraint.
 			$column_constraint_data = $this->extract_column_constraint_data(
@@ -425,7 +482,10 @@ class WP_SQLite_Information_Schema_Builder {
 				'YES' === $column_data['is_nullable']
 			);
 			if ( null !== $column_constraint_data ) {
-				$this->insert_values( 'statistics', $column_constraint_data );
+				$this->insert_values(
+					$this->get_table_name( $table_is_temporary, 'statistics' ),
+					$column_constraint_data
+				);
 			}
 
 			$column_position += 1;
@@ -433,7 +493,7 @@ class WP_SQLite_Information_Schema_Builder {
 
 		// 3. Constraints.
 		foreach ( $node->get_descendant_nodes( 'tableConstraintDef' ) as $constraint_node ) {
-			$this->record_add_constraint( $table_name, $constraint_node );
+			$this->record_add_constraint( $table_is_temporary, $table_name, $constraint_node );
 		}
 	}
 
@@ -446,6 +506,9 @@ class WP_SQLite_Information_Schema_Builder {
 		$table_name = $this->get_value( $node->get_first_descendant_node( 'tableRef' ) );
 		$actions    = $node->get_descendant_nodes( 'alterListItem' );
 
+		// Check if a temporary table with the given name exists.
+		$table_is_temporary = $this->temporary_table_exists( $table_name );
+
 		foreach ( $actions as $action ) {
 			$first_token = $action->get_first_child_token();
 
@@ -456,7 +519,7 @@ class WP_SQLite_Information_Schema_Builder {
 				if ( count( $column_definitions ) > 0 ) {
 					foreach ( $column_definitions as $column_definition ) {
 						$name = $this->get_value( $column_definition->get_first_child_node( 'identifier' ) );
-						$this->record_add_column( $table_name, $name, $column_definition );
+						$this->record_add_column( $table_is_temporary, $table_name, $name, $column_definition );
 					}
 					continue;
 				}
@@ -465,7 +528,7 @@ class WP_SQLite_Information_Schema_Builder {
 				$field_definition = $action->get_first_descendant_node( 'fieldDefinition' );
 				if ( null !== $field_definition ) {
 					$name = $this->get_value( $action->get_first_child_node( 'identifier' ) );
-					$this->record_add_column( $table_name, $name, $field_definition );
+					$this->record_add_column( $table_is_temporary, $table_name, $name, $field_definition );
 					// @TODO: Handle FIRST/AFTER.
 					continue;
 				}
@@ -473,7 +536,7 @@ class WP_SQLite_Information_Schema_Builder {
 				// ADD CONSTRAINT.
 				$constraint = $action->get_first_descendant_node( 'tableConstraintDef' );
 				if ( null !== $constraint ) {
-					$this->record_add_constraint( $table_name, $constraint );
+					$this->record_add_constraint( $table_is_temporary, $table_name, $constraint );
 					continue;
 				}
 
@@ -485,6 +548,7 @@ class WP_SQLite_Information_Schema_Builder {
 				$old_name = $this->get_value( $action->get_first_child_node( 'fieldIdentifier' ) );
 				$new_name = $this->get_value( $action->get_first_child_node( 'identifier' ) );
 				$this->record_change_column(
+					$table_is_temporary,
 					$table_name,
 					$old_name,
 					$new_name,
@@ -497,6 +561,7 @@ class WP_SQLite_Information_Schema_Builder {
 			if ( WP_MySQL_Lexer::MODIFY_SYMBOL === $first_token->id ) {
 				$name = $this->get_value( $action->get_first_child_node( 'fieldIdentifier' ) );
 				$this->record_modify_column(
+					$table_is_temporary,
 					$table_name,
 					$name,
 					$action->get_first_descendant_node( 'fieldDefinition' )
@@ -510,14 +575,14 @@ class WP_SQLite_Information_Schema_Builder {
 				$column_ref = $action->get_first_child_node( 'fieldIdentifier' );
 				if ( null !== $column_ref ) {
 					$name = $this->get_value( $column_ref );
-					$this->record_drop_column( $table_name, $name );
+					$this->record_drop_column( $table_is_temporary, $table_name, $name );
 					continue;
 				}
 
 				// DROP INDEX
 				if ( $action->has_child_node( 'keyOrIndex' ) ) {
 					$name = $this->get_value( $action->get_first_child_node( 'indexRef' ) );
-					$this->record_drop_index( $table_name, $name );
+					$this->record_drop_index( $table_is_temporary, $table_name, $name );
 					continue;
 				}
 			}
@@ -531,29 +596,30 @@ class WP_SQLite_Information_Schema_Builder {
 	 */
 	public function record_drop_table( WP_Parser_Node $node ): void {
 		$child_node = $node->get_first_child_node();
-		if ( $child_node->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL ) ) {
-			return;
-		}
+
+		$has_temporary_keyword = $child_node->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
 
 		$table_refs = $child_node->get_first_child_node( 'tableRefList' )->get_child_nodes();
 		foreach ( $table_refs as $table_ref ) {
-			$table_name = $this->get_value( $table_ref );
+			$table_name         = $this->get_value( $table_ref );
+			$table_is_temporary = $has_temporary_keyword || $this->temporary_table_exists( $table_name );
+
 			$this->delete_values(
-				'tables',
+				$this->get_table_name( $table_is_temporary, 'tables' ),
 				array(
 					'table_schema' => $this->db_name,
 					'table_name'   => $table_name,
 				)
 			);
 			$this->delete_values(
-				'columns',
+				$this->get_table_name( $table_is_temporary, 'columns' ),
 				array(
 					'table_schema' => $this->db_name,
 					'table_name'   => $table_name,
 				)
 			);
 			$this->delete_values(
-				'statistics',
+				$this->get_table_name( $table_is_temporary, 'statistics' ),
 				array(
 					'table_schema' => $this->db_name,
 					'table_name'   => $table_name,
@@ -567,12 +633,18 @@ class WP_SQLite_Information_Schema_Builder {
 	/**
 	 * Analyze ADD COLUMN definition and record data in the information schema.
 	 *
-	 * @param string         $table_name  The table name.
-	 * @param string         $column_name The column name.
-	 * @param WP_Parser_Node $node        The "columnDefinition" or "fieldDefinition" AST node.
+	 * @param bool           $table_is_temporary Whether the table is temporary.
+	 * @param string         $table_name         The table name.
+	 * @param string         $column_name        The column name.
+	 * @param WP_Parser_Node $node               The "columnDefinition" or "fieldDefinition" AST node.
 	 */
-	private function record_add_column( string $table_name, string $column_name, WP_Parser_Node $node ): void {
-		$columns_table_name = $this->get_table_name( 'columns' );
+	private function record_add_column(
+		bool $table_is_temporary,
+		string $table_name,
+		string $column_name,
+		WP_Parser_Node $node
+	): void {
+		$columns_table_name = $this->get_table_name( $table_is_temporary, 'columns' );
 		$position           = $this->query(
 			"
 				SELECT MAX(ordinal_position)
@@ -584,23 +656,31 @@ class WP_SQLite_Information_Schema_Builder {
 		)->fetchColumn();
 
 		$column_data = $this->extract_column_data( $table_name, $column_name, $node, (int) $position + 1 );
-		$this->insert_values( 'columns', $column_data );
+		$this->insert_values(
+			$this->get_table_name( $table_is_temporary, 'columns' ),
+			$column_data
+		);
 
 		$column_constraint_data = $this->extract_column_constraint_data( $table_name, $column_name, $node, true );
 		if ( null !== $column_constraint_data ) {
-			$this->insert_values( 'statistics', $column_constraint_data );
+			$this->insert_values(
+				$this->get_table_name( $table_is_temporary, 'statistics' ),
+				$column_constraint_data
+			);
 		}
 	}
 
 	/**
 	 * Analyze CHANGE COLUMN definition and record data in the information schema.
 	 *
-	 * @param string         $table_name      The table name.
-	 * @param string         $column_name     The column name.
-	 * @param string         $new_column_name The new column name when the column is renamed.
-	 * @param WP_Parser_Node $node            The "fieldDefinition" AST node.
+	 * @param bool           $table_is_temporary Whether the table is temporary.
+	 * @param string         $table_name         The table name.
+	 * @param string         $column_name        The column name.
+	 * @param string         $new_column_name    The new column name when the column is renamed.
+	 * @param WP_Parser_Node $node               The "fieldDefinition" AST node.
 	 */
 	private function record_change_column(
+		bool $table_is_temporary,
 		string $table_name,
 		string $column_name,
 		string $new_column_name,
@@ -608,7 +688,7 @@ class WP_SQLite_Information_Schema_Builder {
 	): void {
 		$column_data = $this->extract_column_data( $table_name, $new_column_name, $node, 0 );
 		$this->update_values(
-			'columns',
+			$this->get_table_name( $table_is_temporary, 'columns' ),
 			$column_data,
 			array(
 				'table_schema' => $this->db_name,
@@ -620,7 +700,7 @@ class WP_SQLite_Information_Schema_Builder {
 		// Update column name in statistics, if it has changed.
 		if ( $new_column_name !== $column_name ) {
 			$this->update_values(
-				'statistics',
+				$this->get_table_name( $table_is_temporary, 'statistics' ),
 				array(
 					'column_name' => $new_column_name,
 				),
@@ -641,35 +721,45 @@ class WP_SQLite_Information_Schema_Builder {
 			'YES' === $column_data['is_nullable']
 		);
 		if ( null !== $column_constraint_data ) {
-			$this->insert_values( 'statistics', $column_constraint_data );
-			$this->sync_column_key_info( $table_name );
+			$this->insert_values(
+				$this->get_table_name( $table_is_temporary, 'statistics' ),
+				$column_constraint_data
+			);
+			$this->sync_column_key_info( $table_is_temporary, $table_name );
 		}
 	}
 
 	/**
 	 * Analyze MODIFY COLUMN definition and record data in the information schema.
 	 *
-	 * @param string         $table_name      The table name.
-	 * @param string         $column_name     The column name.
-	 * @param WP_Parser_Node $node            The "fieldDefinition" AST node.
+	 * @param bool           $table_is_temporary Whether the table is temporary.
+	 * @param string         $table_name         The table name.
+	 * @param string         $column_name        The column name.
+	 * @param WP_Parser_Node $node               The "fieldDefinition" AST node.
 	 */
 	private function record_modify_column(
+		bool $table_is_temporary,
 		string $table_name,
 		string $column_name,
 		WP_Parser_Node $node
 	): void {
-		$this->record_change_column( $table_name, $column_name, $column_name, $node );
+		$this->record_change_column( $table_is_temporary, $table_name, $column_name, $column_name, $node );
 	}
 
 	/**
 	 * Record DROP COLUMN data in the information schema.
 	 *
-	 * @param string $table_name  The table name.
-	 * @param string $column_name The column name.
+	 * @param bool   $table_is_temporary Whether the table is temporary.
+	 * @param string $table_name         The table name.
+	 * @param string $column_name        The column name.
 	 */
-	private function record_drop_column( $table_name, $column_name ): void {
+	private function record_drop_column(
+		bool $table_is_temporary,
+		string $table_name,
+		string $column_name
+	): void {
 		$this->delete_values(
-			'columns',
+			$this->get_table_name( $table_is_temporary, 'columns' ),
 			array(
 				'table_schema' => $this->db_name,
 				'table_name'   => $table_name,
@@ -691,7 +781,7 @@ class WP_SQLite_Information_Schema_Builder {
 		 *   - https://dev.mysql.com/doc/refman/8.4/en/alter-table.html
 		 */
 		$this->delete_values(
-			'statistics',
+			$this->get_table_name( $table_is_temporary, 'statistics' ),
 			array(
 				'table_schema' => $this->db_name,
 				'table_name'   => $table_name,
@@ -701,34 +791,44 @@ class WP_SQLite_Information_Schema_Builder {
 
 		// @TODO: Renumber SEQ_IN_INDEX values.
 
-		$this->sync_column_key_info( $table_name );
+		$this->sync_column_key_info( $table_is_temporary, $table_name );
 	}
 
 	/**
 	 * Record DROP INDEX data in the information schema.
 	 *
-	 * @param string $table_name The table name.
-	 * @param string $index_name The index name.
+	 * @param bool   $table_is_temporary Whether the table is temporary.
+	 * @param string $table_name         The table name.
+	 * @param string $index_name         The index name.
 	 */
-	private function record_drop_index( string $table_name, string $index_name ): void {
+	private function record_drop_index(
+		bool $table_is_temporary,
+		string $table_name,
+		string $index_name
+	): void {
 		$this->delete_values(
-			'statistics',
+			$this->get_table_name( $table_is_temporary, 'statistics' ),
 			array(
 				'table_schema' => $this->db_name,
 				'table_name'   => $table_name,
 				'index_name'   => $index_name,
 			)
 		);
-		$this->sync_column_key_info( $table_name );
+		$this->sync_column_key_info( $table_is_temporary, $table_name );
 	}
 
 	/**
 	 * Analyze ADD CONSTRAINT definition and record data in the information schema.
 	 *
-	 * @param string         $table_name  The table name.
-	 * @param WP_Parser_Node $node        The "tableConstraintDef" AST node.
+	 * @param bool           $table_is_temporary Whether the table is temporary.
+	 * @param string         $table_name         The table name.
+	 * @param WP_Parser_Node $node               The "tableConstraintDef" AST node.
 	 */
-	private function record_add_constraint( string $table_name, WP_Parser_Node $node ): void {
+	private function record_add_constraint(
+		bool $table_is_temporary,
+		string $table_name,
+		WP_Parser_Node $node
+	): void {
 		// Get first constraint keyword.
 		$children = $node->get_children();
 		$keyword  = $children[0] instanceof WP_MySQL_Token ? $children[0] : $children[1];
@@ -763,7 +863,7 @@ class WP_SQLite_Information_Schema_Builder {
 		// Fetch column info.
 		$column_names = array_filter( $key_part_column_names );
 		if ( count( $column_names ) > 0 ) {
-			$columns_table_name = $this->get_table_name( 'columns' );
+			$columns_table_name = $this->get_table_name( $table_is_temporary, 'columns' );
 			$column_info        = $this->query(
 				"
 					SELECT column_name, data_type, is_nullable, character_maximum_length
@@ -814,7 +914,7 @@ class WP_SQLite_Information_Schema_Builder {
 			);
 
 			$this->insert_values(
-				'statistics',
+				$this->get_table_name( $table_is_temporary, 'statistics' ),
 				array(
 					'table_schema'  => $this->db_name,
 					'table_name'    => $table_name,
@@ -839,7 +939,7 @@ class WP_SQLite_Information_Schema_Builder {
 			$seq_in_index += 1;
 		}
 
-		$this->sync_column_key_info( $table_name );
+		$this->sync_column_key_info( $table_is_temporary, $table_name );
 	}
 
 	/**
@@ -941,11 +1041,14 @@ class WP_SQLite_Information_Schema_Builder {
 	 *     4. "":    Column is not indexed.
 	 *
 	 *   B) IS_NULLABLE: In COLUMNS, "YES"/"NO". In STATISTICS, "YES"/"".
+	 *
+	 * @param bool   $table_is_temporary Whether the table is temporary.
+	 * @param string $table_name         The table name.
 	 */
-	private function sync_column_key_info( string $table_name ): void {
+	private function sync_column_key_info( bool $table_is_temporary, string $table_name ): void {
 		// @TODO: Consider listing only affected columns.
-		$columns_table_name    = $this->get_table_name( 'columns' );
-		$statistics_table_name = $this->get_table_name( 'statistics' );
+		$columns_table_name    = $this->get_table_name( $table_is_temporary, 'columns' );
+		$statistics_table_name = $this->get_table_name( $table_is_temporary, 'statistics' );
 		$this->query(
 			"
 				WITH s AS (
@@ -1762,7 +1865,7 @@ class WP_SQLite_Information_Schema_Builder {
 	private function insert_values( string $table_name, array $data ): void {
 		$this->query(
 			'
-				INSERT INTO ' . $this->get_table_name( $table_name ) . ' (' . implode( ', ', array_keys( $data ) ) . ')
+				INSERT INTO ' . $table_name . ' (' . implode( ', ', array_keys( $data ) ) . ')
 				VALUES (' . implode( ', ', array_fill( 0, count( $data ), '?' ) ) . ')
 			',
 			array_values( $data )
@@ -1789,7 +1892,7 @@ class WP_SQLite_Information_Schema_Builder {
 
 		$this->query(
 			'
-				UPDATE ' . $this->get_table_name( $table_name ) . '
+				UPDATE ' . $table_name . '
 				SET ' . implode( ', ', $set ) . '
 				WHERE ' . implode( ' AND ', $where_clause ) . '
 			',
@@ -1811,7 +1914,7 @@ class WP_SQLite_Information_Schema_Builder {
 
 		$this->query(
 			'
-				DELETE FROM ' . $this->get_table_name( $table_name ) . '
+				DELETE FROM ' . $table_name . '
 				WHERE ' . implode( ' AND ', $where_clause ) . '
 			',
 			array_values( $where )

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -348,6 +348,16 @@ class WP_SQLite_Information_Schema_Builder {
 	private $temporary_table_prefix;
 
 	/**
+	 * Whether the information schema for temporary tables was already created.
+	 *
+	 * This is used to avoid trying to create a temporary information schema
+	 * for each CREATE TEMPORARY TABLE statement during a single session.
+	 *
+	 * @var bool
+	 */
+	private $temporary_information_schema_exists = false;
+
+	/**
 	 * Query callback.
 	 *
 	 * @TODO: Consider extracting a part of the WP_SQLite_Driver class
@@ -420,6 +430,7 @@ class WP_SQLite_Information_Schema_Builder {
 			$query = str_replace( 'CREATE TABLE', 'CREATE TEMPORARY TABLE', $query );
 			$this->query( str_replace( '<prefix>', $this->temporary_table_prefix, $query ) );
 		}
+		$this->temporary_information_schema_exists = true;
 	}
 
 	/**
@@ -440,22 +451,39 @@ class WP_SQLite_Information_Schema_Builder {
 		 */
 		$subnode            = $node->get_first_child_node();
 		$table_is_temporary = $subnode->has_child_token( WP_MySQL_Lexer::TEMPORARY_SYMBOL );
-		if ( true === $table_is_temporary ) {
+		if ( $table_is_temporary && ! $this->temporary_information_schema_exists ) {
 			$this->ensure_temporary_information_schema_tables();
 		}
 
 		// 1. Table.
-		$this->insert_values(
-			$this->get_table_name( $table_is_temporary, 'tables' ),
-			array(
-				'table_schema'    => $this->db_name,
-				'table_name'      => $table_name,
-				'table_type'      => 'BASE TABLE',
-				'engine'          => $table_engine,
-				'row_format'      => $table_row_format,
-				'table_collation' => $table_collation,
-			)
+		$tables_table_name = $this->get_table_name( $table_is_temporary, 'tables' );
+		$table_data        = array(
+			'table_schema'    => $this->db_name,
+			'table_name'      => $table_name,
+			'table_type'      => 'BASE TABLE',
+			'engine'          => $table_engine,
+			'row_format'      => $table_row_format,
+			'table_collation' => $table_collation,
 		);
+
+		try {
+			$this->insert_values( $tables_table_name, $table_data );
+		} catch ( PDOException $e ) {
+			/*
+			 * Even though we keep track of whether the temporary information
+			 * schema tables already exist, there is a special case in which
+			 * the tracked information may be incorrect.
+			 *
+			 * This can happen when the query is in a transaction that is later
+			 * rolled back. In that case, let's ensure the schema, and try again.
+			 */
+			if ( $table_is_temporary && str_contains( $e->getMessage(), 'no such table' ) ) {
+				$this->ensure_temporary_information_schema_tables();
+				$this->insert_values( $tables_table_name, $table_data );
+			} else {
+				throw $e;
+			}
+		}
 
 		// 2. Columns.
 		$column_position = 1;


### PR DESCRIPTION
This PR implements a correct temporary table support using additional information schema tables for the temporary tables. These additional information schema tables are themselves temporary, and are created lazily (on the first `CREATE TEMPORARY TABLE` statement).

These changes correctly implement cases such as the following scenario:
```sql
CREATE TABLE t (a INT, INDEX ia(a));
CREATE TEMPORARY TABLE t (b INT, INDEX ib(b));

-- The temporary table has priority over the standard table:
SHOW CREATE TABLE t; -- CREATE TEMPORARY TABLE `t` ( `b` int DEFAULT NULL, KEY `ib` (`b`) ) ...
SHOW COLUMNS FROM t; -- Field: b, ...
DESCRIBE t;          -- Field: b, ...
SHOW INDEXES FROM t; -- Key_name: b

-- We can also ALTER it:
ALTER TABLE t ADD COLUMN c INT;
SHOW COLUMNS FROM t;  -- Field: b, ...
                      -- Field: c, ...

-- But it doesn't show up in information schema:
SELECT * FROM information_schema.columns WHERE table_name = 't'; -- COLUMN_NAME: a

-- Simple DROP TABLE also goes after the temporary table first:
DROP TABLE t;
SHOW COLUMNS FROM t; -- Field: a, ...
DROP TABLE t;
SHOW COLUMNS FROM t; -- Now "Table doesn't exist"
```