### PR TITLE
Fix warnings on site health screen

### DIFF
--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -78,7 +78,7 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				'TABLE_CATALOG'   => 'def',
-				'TABLE_SCHEMA'    => 'database',
+				'TABLE_SCHEMA'    => '',
 				'TABLE_NAME'      => 'wp_options',
 				'TABLE_TYPE'      => 'BASE TABLE',
 				'ENGINE'          => 'InnoDB',

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1528,14 +1528,16 @@ class WP_SQLite_Translator {
 
 		if ( $table_name && str_starts_with( strtolower( $table_name ), 'information_schema' ) ) {
 			$this->is_information_schema_query = true;
-			$updated_query                     = preg_replace(
+
+			$database_name = $this->pdo->quote( defined( 'DB_NAME' ) ? DB_NAME : '' );
+			$updated_query = preg_replace(
 				'/' . $table_name . '\.tables/i',
 				/**
 				 * TODO: Return real values for hardcoded column values.
 				 */
 				"(SELECT
 					'def' as TABLE_CATALOG,
-					'database' as TABLE_SCHEMA,
+					$database_name as TABLE_SCHEMA,
 					name as TABLE_NAME,
 					CASE type
 					WHEN 'table' THEN 'BASE TABLE'


### PR DESCRIPTION
Information schema subqueries need to provide the actual database name, so that parent queries that compare against it return some data.

Fixes:

```
Warning: Undefined array key "wp_comments" in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Attempt to read property "rows" on null in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Undefined array key "wp_options" in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Attempt to read property "rows" on null in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Undefined array key "wp_posts" in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Attempt to read property "rows" on null in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Undefined array key "wp_terms" in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Attempt to read property "rows" on null in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Undefined array key "wp_users" in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
Warning: Attempt to read property "rows" on null in /var/www/html/wp-admin/includes/class-wp-site-health.php on line 3586
```