### PR TITLE
Check if $_ENV['WP_SQLITE_AST_DRIVER'] is defined

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -53,6 +53,6 @@ if ( ! defined( 'FQDB' ) ) {
 }
 
 // Allow enabling the SQLite AST driver via environment variable.
-if ( ! defined( 'WP_SQLITE_AST_DRIVER' ) && 'true' === $_ENV['WP_SQLITE_AST_DRIVER'] ) {
+if ( ! defined( 'WP_SQLITE_AST_DRIVER' ) && isset( $_ENV['WP_SQLITE_AST_DRIVER'] ) && 'true' === $_ENV['WP_SQLITE_AST_DRIVER'] ) {
 	define( 'WP_SQLITE_AST_DRIVER', true );
 }


### PR DESCRIPTION
If both `WP_SQLITE_AST_DRIVER` and `$_ENV['WP_SQLITE_AST_DRIVER']` aren't defined the SQLite database integration plugin plugin throws a warning on the site.

`Warning: Undefined array key "WP_SQLITE_AST_DRIVER" in /var/www/html/wp-content/mu-plugins/sqlite-database-integration/constants.php on line 56`

This fix ensures `$_ENV['WP_SQLITE_AST_DRIVER']` is set before reading it. 