### PR TITLE
2.1.18-alpha release branch

### DIFF
--- a/load.php
+++ b/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 2.1.17-alpha
+ * Version: 2.1.18-alpha
  * Requires PHP: 7.0
  * Textdomain: sqlite-database-integration
  *

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      6.6.1
 Requires PHP:      7.0
-Stable tag:        2.1.17-alpha
+Stable tag:        2.1.18-alpha
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, database

--- a/tests/WP_SQLite_Metadata_Tests.php
+++ b/tests/WP_SQLite_Metadata_Tests.php
@@ -78,7 +78,7 @@ class WP_SQLite_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				'TABLE_CATALOG'   => 'def',
-				'TABLE_SCHEMA'    => 'database',
+				'TABLE_SCHEMA'    => '',
 				'TABLE_NAME'      => 'wp_options',
 				'TABLE_TYPE'      => 'BASE TABLE',
 				'ENGINE'          => 'InnoDB',

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1519,14 +1519,16 @@ class WP_SQLite_Translator {
 
 		if ( $table_name && str_starts_with( strtolower( $table_name ), 'information_schema' ) ) {
 			$this->is_information_schema_query = true;
-			$updated_query                     = preg_replace(
+
+			$database_name = $this->pdo->quote( defined( 'DB_NAME' ) ? DB_NAME : '' );
+			$updated_query = preg_replace(
 				'/' . $table_name . '\.tables/i',
 				/**
 				 * TODO: Return real values for hardcoded column values.
 				 */
 				"(SELECT
 					'def' as TABLE_CATALOG,
-					'database' as TABLE_SCHEMA,
+					$database_name as TABLE_SCHEMA,
 					name as TABLE_NAME,
 					CASE type
 					WHEN 'table' THEN 'BASE TABLE'


### PR DESCRIPTION
We want to release a new version of the SQLite database integration plugin for Studio with [Fix warnings on site health screen](https://github.com/Automattic/sqlite-database-integration/commit/05d72cc0d02032a808ac36cc5c85aa974eff2a4a).

This branch includes the necessary commits from `develop` and will be used as the release branch.

We previously attempted to release a version from `develop`, but encountered multiple issues, so for stability reasons we will ended up charry picking the necessary commits instead of releasing a version based on `develop`.