### PR TITLE
Fix deprecation of implicitly marking parameter as nullable in PHP 8.4

### DIFF
--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver-exception.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver-exception.php
@@ -20,7 +20,7 @@ class WP_SQLite_Driver_Exception extends PDOException {
 		WP_SQLite_Driver $driver,
 		string $message,
 		$code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	) {
 		parent::__construct( $message, 0, $previous );
 		$this->code   = $code;

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2783,7 +2783,7 @@ class WP_SQLite_Driver {
 	private function recreate_table_from_information_schema(
 		bool $table_is_temporary,
 		string $table_name,
-		array $column_map = null
+		?array $column_map = null
 	): void {
 		if ( null === $column_map ) {
 			$columns_table = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
@@ -3538,7 +3538,7 @@ class WP_SQLite_Driver {
 	 *
 	 * @param int|null $override Override the affected rows.
 	 */
-	private function set_result_from_affected_rows( int $override = null ): void {
+	private function set_result_from_affected_rows( ?int $override = null ): void {
 		/*
 		 * SELECT CHANGES() is a workaround for the fact that $stmt->rowCount()
 		 * returns "0" (zero) with the SQLite driver at all times.
@@ -3564,7 +3564,7 @@ class WP_SQLite_Driver {
 	private function new_driver_exception(
 		string $message,
 		$code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	): WP_SQLite_Driver_Exception {
 		return new WP_SQLite_Driver_Exception( $this, $message, $code, $previous );
 	}


### PR DESCRIPTION
Fixes the following errors from [Playground Compatibility Reports](https://github.com/bgrgicak/Playground-compatibility-reports/blob/main/reports/ast-errors.md):

```
WP_SQLite_Driver::recreate_table_from_information_schema(): Implicitly marking parameter $column_map as nullable is deprecated, the explicit nullable type must be used instead in /internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-driver.php on line 2783

WP_SQLite_Driver::set_result_from_affected_rows(): Implicitly marking parameter $override as nullable is deprecated, the explicit nullable type must be used instead in /internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-driver.php on line 3541

WP_SQLite_Driver::new_driver_exception(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-driver.php on line 3564

WP_SQLite_Driver_Exception::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-driver-exception.php on line 19
```

