### PR TITLE
Add a hotfix for missing `DB_NAME` constant

### DIFF
--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -51,6 +51,20 @@ require_once __DIR__ . '/class-wp-sqlite-db.php';
 require_once __DIR__ . '/install-functions.php';
 
 /*
+ * Fallback to a default database name if "DB_NAME" is not defined.
+ *
+ * This can happen when importing a WordPress backup that doesn't include the
+ * "DB_NAME" constant definition.
+ *
+ * TODO: Remove this once addressed in WordPress Playground, which is a more
+ *       appropriate place to fix this. In the SQLite integration plugin, it is
+ *       better to require the "DB_NAME" constant to be defined to avoid issues
+ *       such as storing an incorrect database name in the information schema.
+ */
+// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
+$db_name = defined( 'DB_NAME' ) ? DB_NAME : 'wordpress';
+
+/*
  * Debug: Cross-check with MySQL.
  * This is for debugging purpose only and requires files
  * that are present in the GitHub repository
@@ -59,7 +73,9 @@ require_once __DIR__ . '/install-functions.php';
 $crosscheck_tests_file_path = dirname( __DIR__, 2 ) . '/tests/class-wp-sqlite-crosscheck-db.php';
 if ( defined( 'SQLITE_DEBUG_CROSSCHECK' ) && SQLITE_DEBUG_CROSSCHECK && file_exists( $crosscheck_tests_file_path ) ) {
 	require_once $crosscheck_tests_file_path;
-	$GLOBALS['wpdb'] = new WP_SQLite_Crosscheck_DB( DB_NAME );
+	$GLOBALS['wpdb'] = new WP_SQLite_Crosscheck_DB( $db_name );
 } else {
-	$GLOBALS['wpdb'] = new WP_SQLite_DB( DB_NAME );
+	$GLOBALS['wpdb'] = new WP_SQLite_DB( $db_name );
 }
+
+unset( $db_name );


### PR DESCRIPTION
A hotfix for:

```
Fatal error: Uncaught Error: Undefined constant "DB_NAME" in /var/www/html/wp-content/mu-plugins/sqlite-database-integration/wp-includes/sqlite/db.php:64 Stack trace: #0 /var/www/html/wp-content/db.php(37): require_once() #1 /var/www/html/wp-includes/load.php(683): require_once('/var/www/html/w...') #2 /var/www/html/wp-settings.php(133): require_wp_db() #3 /var/www/html/wp-config.php(85): require_once('/var/www/html/w...') #4 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...') #5 /var/www/html/wp-blog-header.php(13): require_once('/var/www/html/w...') #6 /var/www/html/index.php(17): require('/var/www/html/w...') #7 {main} thrown in /var/www/html/wp-content/mu-plugins/sqlite-database-integration/wp-includes/sqlite/db.php on line 64
```

This error occurs when importing a site backup in Studio that doesn't define the `DB_NAME` constant.

The ideal solution is to address this in Playground, but in the meantime, we can use a hotfix.

Fixes https://github.com/Automattic/sqlite-database-integration/issues/40.