### PR TITLE
Add PHP 8.4 unit tests to CI

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         # NOTE: There does not appear to be a single phpunit version that supports all
         # PHP versions tested here. For now, we are removing PHP 7.0. and 7.1 tests
         # in order to run a single phpunit version for PHP 7.2 and up.
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
We've had some PHP 8.4 issues: https://github.com/Automattic/sqlite-database-integration/pull/43

Let's test with PHP 8.4 as well.