### PR TITLE
Fix identifier (un)escaping

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4703,4 +4703,233 @@ QUERY
 		$this->assertSame( "SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'idx'", $exception->getMessage() );
 		$this->assertSame( '42S21', $exception->getCode() );
 	}
+
+	public function testNoBackslashEscapesSqlMode(): void {
+		$backslash = chr( 92 );
+
+		$query = "SELECT
+			''''                       AS value_1,
+			'{$backslash}\"'           AS value_2,
+			'{$backslash}0'            AS value_3,
+			'{$backslash}n'            AS value_4,
+			'{$backslash}r'            AS value_5,
+			'{$backslash}t'            AS value_6,
+			'{$backslash}b'            AS value_7,
+			'{$backslash}{$backslash}' AS value_8,
+			'🙂'                        AS value_9,
+			'{$backslash}🙂'            AS value_10,
+			'{$backslash}%'            AS value_11,
+			'{$backslash}_'            AS value_12
+		";
+
+		// With NO_BACKSLASH_ESCAPES disabled:
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+		$result = $this->assertQuery( $query );
+		$this->assertSame( chr( 39 ), $result[0]->value_1 ); // single quote
+		$this->assertSame( chr( 34 ), $result[0]->value_2 ); // double quote
+		$this->assertSame( chr( 0 ), $result[0]->value_3 );  // ASCII NULL
+		$this->assertSame( chr( 10 ), $result[0]->value_4 ); // newline
+		$this->assertSame( chr( 13 ), $result[0]->value_5 ); // carriage return
+		$this->assertSame( chr( 9 ), $result[0]->value_6 );  // tab
+		$this->assertSame( chr( 8 ), $result[0]->value_7 );  // backspace
+		$this->assertSame( chr( 92 ), $result[0]->value_8 ); // backslash
+		$this->assertSame( '🙂', $result[0]->value_9 );
+		$this->assertSame( '🙂', $result[0]->value_10 );
+
+		// Characters "%" and "_" follow special escaping rules. Escape sequences
+		// "\%" and "\_" preserve the backslash so it can be used in some contexts.
+		$this->assertSame( $backslash . '%', $result[0]->value_11 );
+		$this->assertSame( $backslash . '_', $result[0]->value_12 );
+
+		// With NO_BACKSLASH_ESCAPES enabled:
+		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+		$result = $this->assertQuery( $query );
+		$this->assertSame( "'", $result[0]->value_1 );
+		$this->assertSame( $backslash . '"', $result[0]->value_2 );
+		$this->assertSame( $backslash . '0', $result[0]->value_3 );
+		$this->assertSame( $backslash . 'n', $result[0]->value_4 );
+		$this->assertSame( $backslash . 'r', $result[0]->value_5 );
+		$this->assertSame( $backslash . 't', $result[0]->value_6 );
+		$this->assertSame( $backslash . 'b', $result[0]->value_7 );
+		$this->assertSame( $backslash . $backslash, $result[0]->value_8 );
+		$this->assertSame( '🙂', $result[0]->value_9 );
+		$this->assertSame( $backslash . '🙂', $result[0]->value_10 );
+		$this->assertSame( $backslash . '%', $result[0]->value_11 );
+		$this->assertSame( $backslash . '_', $result[0]->value_12 );
+	}
+
+	public function testNoBackslashEscapesSqlModeWithPatternMatching(): void {
+		$backslash = chr( 92 );
+
+		$this->assertQuery( 'CREATE TABLE t (id INT PRIMARY KEY AUTO_INCREMENT, value TEXT)' );
+		$this->assertQuery( "INSERT INTO t (value) VALUES ('abc')" );
+		$this->assertQuery( "INSERT INTO t (value) VALUES ('abc_')" );
+		$this->assertQuery( "INSERT INTO t (value) VALUES ('abc%')" );
+		$this->assertQuery( "INSERT INTO t (value) VALUES ('abc{$backslash}{$backslash}x')" ); // abc\x
+
+		/*
+		 * 1. With NO_BACKSLASH_ESCAPES disabled:
+		 *
+		 * Backslashes serve as special escape characters on two levels:
+		 *
+		 *   1. In MySQL string literals.
+		 *   2. In LIKE patterns.
+		 *
+		 * Additionally, "\_" and "\%" sequences preserve the backslash in MySQL
+		 * string literals, making them equivalent to "\\_" and "\\%" sequences.
+		 *
+		 * Here's what that does to some escape sequences:
+		 *
+		 *   "\_"
+		 *      1) String literal resolves to:   "\_" sequence
+		 *      2) Pattern matching resolves to: "_" character
+		 *
+		 *   "\\_"
+		 *      1) String literal resolves to:   "\_" sequence
+		 *      2) Pattern matching resolves to: "_" character
+		 *
+		 *   "\\\_"
+		 *      1) String literal resolves to:   "\\_" sequence
+		 *      2) Pattern matching resolves to: "\" character + "_" wildcard
+		 *
+		 *   "\\\\_"
+		 *      1) String literal resolves to:   "\\_" sequence
+		 *      2) Pattern matching resolves to: "\" character + "_" wildcard
+		 *
+		 * The same rules applies to the "%" character.
+		 */
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+
+		// A "_" = a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc_' ORDER BY id" );
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'abc_', $result[0]->value );
+		$this->assertSame( 'abc%', $result[1]->value );
+
+		// A "\_" sequence = the "_" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}_'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'abc_', $result[0]->value );
+
+		// A "\\_" sequence = the "_" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}_'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'abc_', $result[0]->value );
+
+		// A "\\\_" sequence = the "\" character and a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}_'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\\\_" sequence = the "\" character and a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}{$backslash}_'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\\\\_" sequence = the "\" character and the "_" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}{$backslash}{$backslash}_'" );
+		$this->assertCount( 0, $result );
+
+		// A "%" = a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc%' ORDER BY id" );
+		$this->assertCount( 4, $result );
+		$this->assertSame( 'abc', $result[0]->value );
+		$this->assertSame( 'abc_', $result[1]->value );
+		$this->assertSame( 'abc%', $result[2]->value );
+		$this->assertSame( "abc{$backslash}x", $result[3]->value );
+
+		// A "\%" sequence = the "%" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}%'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'abc%', $result[0]->value );
+
+		// A "\\%" sequence = the "%" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}%'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'abc%', $result[0]->value );
+
+		// A "\\\%" sequence = the "\" character and a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}%'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\\\%" sequence = the "\" character and a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}{$backslash}%'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\\\\%" sequence = the "\" character and the "%" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}{$backslash}{$backslash}%'" );
+		$this->assertCount( 0, $result );
+
+		// A "\x" sequence = the "x" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}x'" );
+		$this->assertCount( 0, $result );
+
+		// A "\\x" sequence = the "x" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}x'" );
+		$this->assertCount( 0, $result );
+
+		// A "\\\x" sequence = the "x" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}x'" );
+		$this->assertCount( 0, $result );
+
+		// A "\\\\x" sequence = the "\" character and the "x" character:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}{$backslash}x'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		/*
+		 * 2. With NO_BACKSLASH_ESCAPES enabled:
+		 *
+		 * Backslashes don't serve as special escape characters at all:
+		 *
+		 *   1. No special meaning in MySQL string literals.
+		 *   2. No special meaning in LIKE patterns.
+		 *      This can be overriden using the "ESCAPE ..." clause of the LIKE
+		 *      expression. This is not implemented in the SQLite driver yet.
+		 */
+		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+
+		// A "_" = a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc_' ORDER BY id" );
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'abc_', $result[0]->value );
+		$this->assertSame( 'abc%', $result[1]->value );
+
+		// A "\_" sequence = the "\" character and a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}_'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\_" sequence = two "\" characters and a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}_'" );
+		$this->assertCount( 0, $result );
+
+		// A "%" = a wildcard:
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc%' ORDER BY id" );
+		$this->assertCount( 4, $result );
+		$this->assertSame( 'abc', $result[0]->value );
+		$this->assertSame( 'abc_', $result[1]->value );
+		$this->assertSame( 'abc%', $result[2]->value );
+		$this->assertSame( "abc{$backslash}x", $result[3]->value );
+
+		// A "\%" sequence = the "\" character and a wildcard.
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}%'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\%" sequence = two "\" characters and a wildcard.
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}%'" );
+		$this->assertCount( 0, $result );
+
+		// A "\x" sequence = the "\" and the "x" character.
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}x'" );
+		$this->assertCount( 1, $result );
+		$this->assertSame( "abc{$backslash}x", $result[0]->value );
+
+		// A "\\x" sequence = two "\" characters and the "x" character.
+		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}x'" );
+		$this->assertCount( 0, $result );
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -429,26 +429,59 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		);
 	}
 
-	public function testShowCreateTableWithCorrectDefaultValues() {
+	public function testShowCreateTableWithDefaultValues(): void {
 		$this->assertQuery(
 			"CREATE TABLE _tmp__table (
-					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-					default_empty_string VARCHAR(255) default '',
-					null_no_default VARCHAR(255)
-				);"
+				ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				no_default VARCHAR(255),
+				default_zero INT DEFAULT 0,
+				default_empty_string VARCHAR(255) DEFAULT '',
+				special_chars_1 TEXT NOT NULL COMMENT '\'',
+				special_chars_2 TEXT NOT NULL COMMENT '''',
+				special_chars_3 TEXT NOT NULL COMMENT '\"',
+				special_chars_4 TEXT NOT NULL COMMENT '\\\"',
+				special_chars_5 TEXT NOT NULL COMMENT '`',
+				special_chars_6 TEXT NOT NULL COMMENT '\0',
+				special_chars_7 TEXT NOT NULL COMMENT '\n',
+				special_chars_8 TEXT NOT NULL COMMENT '\r',
+				special_chars_9 TEXT NOT NULL COMMENT '\t',
+				special_chars_10 TEXT NOT NULL COMMENT '\032',
+				special_chars_11 TEXT NOT NULL COMMENT '\\\\',
+				special_chars_12 TEXT NOT NULL COMMENT '🙂',
+				special_chars_13 TEXT NOT NULL COMMENT '\🙂'
+			)"
 		);
 
 		$this->assertQuery(
 			'SHOW CREATE TABLE _tmp__table;'
 		);
 		$results = $this->engine->get_query_results();
-		$this->assertEquals(
-			'CREATE TABLE `_tmp__table` (
-  `ID` bigint NOT NULL AUTO_INCREMENT,
-  `default_empty_string` varchar(255) DEFAULT \'\',
-  `null_no_default` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`ID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `_tmp__table` (',
+					'  `ID` bigint NOT NULL AUTO_INCREMENT,',
+					'  `no_default` varchar(255) DEFAULT NULL,',
+					"  `default_zero` int DEFAULT '0',",
+					"  `default_empty_string` varchar(255) DEFAULT '',",
+					"  `special_chars_1` text NOT NULL COMMENT '''',",
+					"  `special_chars_2` text NOT NULL COMMENT '''',",
+					"  `special_chars_3` text NOT NULL COMMENT '\"',",
+					"  `special_chars_4` text NOT NULL COMMENT '\"',",
+					"  `special_chars_5` text NOT NULL COMMENT '`',",
+					"  `special_chars_6` text NOT NULL COMMENT '\\0',",
+					"  `special_chars_7` text NOT NULL COMMENT '\\n',",
+					"  `special_chars_8` text NOT NULL COMMENT '\\r',",
+					"  `special_chars_9` text NOT NULL COMMENT '	',",
+					"  `special_chars_10` text NOT NULL COMMENT '" . chr( 26 ) . "',",
+					"  `special_chars_11` text NOT NULL COMMENT '\\\\',",
+					"  `special_chars_12` text NOT NULL COMMENT '🙂',",
+					"  `special_chars_13` text NOT NULL COMMENT '🙂',",
+					'  PRIMARY KEY (`ID`)',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+				)
+			),
 			$results[0]->{'Create Table'}
 		);
 	}

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4972,10 +4972,33 @@ QUERY
 		$this->assertSame( "'👪'", $quote( '👪' ) );
 		$this->assertSame( "'Ʈềʂᴛӏń𝒈 𝙨𝑜ɱê Ū𝐓Ϝ-8 𝒄𝒽ȃᵲ𝛼çṱ𝘦ᴦ𐑈.'", $quote( 'Ʈềʂᴛӏń𝒈 𝙨𝑜ɱê Ū𝐓Ϝ-8 𝒄𝒽ȃᵲ𝛼çṱ𝘦ᴦ𐑈.' ) );
 
-		// Invalid UTF-8 sequences may fail to be preserved.
-		// The following 2-byte sequence with a single quote as the last byte
-		// is not a valid UTF-8 sequence. The single quote gets escaped.
-		// At the moment, this is the intended behavior.
+		// Invalid UTF-8: An incomplete 2-byte sequence is left unchanged.
+		$this->assertSame(
+			"'" . chr( 0xC0 ) . "'",
+			$quote( chr( 0xC0 ) )
+		);
+
+		// Invalid UTF-8: A surrogate pair is left unchanged.
+		$this->assertSame(
+			"'" . chr( 0xED ) . chr( 0xA0 ) . chr( 0x80 ) . "'",
+			$quote( chr( 0xED ) . chr( 0xA0 ) . chr( 0x80 ) )
+		);
+
+		// Invalid UTF-8: Overlong encoding of ASCII NULL is left unchanged.
+		$this->assertSame(
+			"'" . chr( 0xE0 ) . chr( 0x80 ) . chr( 0x80 ) . "'",
+			$quote( chr( 0xE0 ) . chr( 0x80 ) . chr( 0x80 ) )
+		);
+
+		// Invalid UTF-8: A 2-byte sequence prefix, followed by an ASCII NULL.
+		// The NULL is escaped, leaving the C0 prefix an incomplete sequence.
+		$this->assertSame(
+			"'" . chr( 0xC0 ) . "{$backslash}0" . "'",
+			$quote( chr( 0xC0 ) . chr( 0 ) )
+		);
+
+		// Invalid UTF-8: A 2-byte sequence prefix, followed by a single quote.
+		// The single quote is escaped, leaving the C0 prefix an incomplete sequence.
 		$this->assertSame(
 			"'" . chr( 0xC0 ) . chr( 39 ) . chr( 39 ) . "'",
 			$quote( chr( 0xC0 ) . chr( 39 ) )

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -343,6 +343,59 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		);
 	}
 
+	public function testShowCreateTableWithComments(): void {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				id INT NOT NULL COMMENT 'Column 1 comment',
+				name VARCHAR(255) NULL DEFAULT 'test' COMMENT 'Column 2 comment',
+				special_chars_1 TEXT NOT NULL COMMENT '\'',
+				special_chars_2 TEXT NOT NULL COMMENT '''',
+				special_chars_3 TEXT NOT NULL COMMENT '\"',
+				special_chars_4 TEXT NOT NULL COMMENT '\\\"',
+				special_chars_5 TEXT NOT NULL COMMENT '`',
+				special_chars_6 TEXT NOT NULL COMMENT '\0',
+				special_chars_7 TEXT NOT NULL COMMENT '\n',
+				special_chars_8 TEXT NOT NULL COMMENT '\r',
+				special_chars_9 TEXT NOT NULL COMMENT '\t',
+				special_chars_10 TEXT NOT NULL COMMENT '\032',
+				special_chars_11 TEXT NOT NULL COMMENT '\\\\',
+				special_chars_12 TEXT NOT NULL COMMENT '🙂',
+				special_chars_13 TEXT NOT NULL COMMENT '\🙂',
+				INDEX idx_id (id) COMMENT 'Index comment'
+			) COMMENT='Table comment'"
+		);
+
+		$results = $this->assertQuery(
+			'SHOW CREATE TABLE _tmp_table;'
+		);
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `_tmp_table` (',
+					"  `id` int NOT NULL COMMENT 'Column 1 comment',",
+					"  `name` varchar(255) DEFAULT 'test' COMMENT 'Column 2 comment',",
+					"  `special_chars_1` text NOT NULL COMMENT '''',",
+					"  `special_chars_2` text NOT NULL COMMENT '''',",
+					"  `special_chars_3` text NOT NULL COMMENT '\"',",
+					"  `special_chars_4` text NOT NULL COMMENT '\"',",
+					"  `special_chars_5` text NOT NULL COMMENT '`',",
+					"  `special_chars_6` text NOT NULL COMMENT '\\0',",
+					"  `special_chars_7` text NOT NULL COMMENT '\\n',",
+					"  `special_chars_8` text NOT NULL COMMENT '\\r',",
+					"  `special_chars_9` text NOT NULL COMMENT '	',",
+					"  `special_chars_10` text NOT NULL COMMENT '" . chr( 26 ) . "',",
+					"  `special_chars_11` text NOT NULL COMMENT '\\\\',",
+					"  `special_chars_12` text NOT NULL COMMENT '🙂',",
+					"  `special_chars_13` text NOT NULL COMMENT '🙂',",
+					"  KEY `idx_id` (`id`) COMMENT 'Index comment'",
+					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Table comment'",
+				)
+			),
+			$results[0]->{'Create Table'}
+		);
+	}
+
 	public function testCreateTablesWithIdenticalIndexNames() {
 		$this->assertQuery(
 			"CREATE TABLE _tmp_table_a (

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4932,4 +4932,53 @@ QUERY
 		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}x'" );
 		$this->assertCount( 0, $result );
 	}
+
+	public function testQuoteMysqlUtf8StringLiteral(): void {
+		// WP_SQLite_Driver::quote_mysql_utf8_string_literal() is a private method.
+		// Let's use a closure bound to the driver instance to access it for tests.
+		$quote = Closure::bind(
+			function ( string $utf8_literal ) {
+				return $this->quote_mysql_utf8_string_literal( $utf8_literal );
+			},
+			$this->engine,
+			WP_SQLite_Driver::class
+		);
+
+		$backslash = chr( 92 );
+
+		// The formatted string must be enclosed in single quotes.
+		$this->assertSame( "'abc'", $quote( 'abc' ) );
+
+		// Single quotes must be escaped by being doubled.
+		$this->assertSame( "''''", $quote( chr( 39 ) ) );
+		$this->assertSame( "'abc''xyz'", $quote( "abc'xyz" ) );
+
+		// Backslashes must be escaped by being doubled.
+		$this->assertSame( "'{$backslash}{$backslash}'", $quote( $backslash ) );
+		$this->assertSame( "'abc{$backslash}{$backslash}xyz'", $quote( "abc{$backslash}xyz" ) );
+
+		// ASCII NULL, newline, and carriage return must be escaped with a backslash.
+		$this->assertSame( "'{$backslash}0'", $quote( chr( 0 ) ) );  // ASCII NULL (\0)
+		$this->assertSame( "'{$backslash}n'", $quote( chr( 10 ) ) ); // newline (\n)
+		$this->assertSame( "'{$backslash}r'", $quote( chr( 13 ) ) ); // carriage return (\r)
+
+		// Other valid UTF-8 characters must be preserved.
+		$this->assertSame( "'" . chr( 34 ) . "'", $quote( chr( 34 ) ) ); // double quote
+		$this->assertSame( "'" . chr( 96 ) . "'", $quote( chr( 96 ) ) ); // backtick
+		$this->assertSame( "'" . chr( 8 ) . "'", $quote( chr( 8 ) ) );   // backspace
+		$this->assertSame( "'" . chr( 9 ) . "'", $quote( chr( 9 ) ) );   // tab
+		$this->assertSame( "'" . chr( 26 ) . "'", $quote( chr( 26 ) ) ); // Control+Z
+		$this->assertSame( "'🙂'", $quote( '🙂' ) );
+		$this->assertSame( "'👪'", $quote( '👪' ) );
+		$this->assertSame( "'Ʈềʂᴛӏń𝒈 𝙨𝑜ɱê Ū𝐓Ϝ-8 𝒄𝒽ȃᵲ𝛼çṱ𝘦ᴦ𐑈.'", $quote( 'Ʈềʂᴛӏń𝒈 𝙨𝑜ɱê Ū𝐓Ϝ-8 𝒄𝒽ȃᵲ𝛼çṱ𝘦ᴦ𐑈.' ) );
+
+		// Invalid UTF-8 sequences may fail to be preserved.
+		// The following 2-byte sequence with a single quote as the last byte
+		// is not a valid UTF-8 sequence. The single quote gets escaped.
+		// At the moment, this is the intended behavior.
+		$this->assertSame(
+			"'" . chr( 0xC0 ) . chr( 39 ) . chr( 39 ) . "'",
+			$quote( chr( 0xC0 ) . chr( 39 ) )
+		);
+	}
 }

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -206,8 +206,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', '', 'select,insert,update,references', '', '', null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
@@ -225,8 +225,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -248,8 +248,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
@@ -270,8 +270,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'MyISAM', 'Fixed', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'MyISAM', 'Fixed', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', '', 'select,insert,update,references', '', '', null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
@@ -290,8 +290,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_czech_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_czech_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', '', 'select,insert,update,references', '', '', null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
@@ -318,8 +318,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
@@ -340,8 +340,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't1', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't1', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't1', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
@@ -360,8 +360,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't2', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't2', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't2', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
@@ -380,8 +380,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't3', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't3', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't3', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				"SELECT column_name, data_type, is_nullable, character_maximum_length FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't3' AND column_name IN ('id')",
@@ -407,8 +407,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', 'UNI', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
@@ -436,8 +436,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -779,8 +779,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'i1', 1, null, 'YES', 'bit', null, null, 1, null, null, null, null, 'bit(1)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -800,8 +800,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'i1', 1, null, 'YES', 'tinyint', null, null, 3, 0, null, null, null, 'tinyint(1)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -821,8 +821,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'i1', 1, null, 'YES', 'tinyint', null, null, 3, 0, null, null, null, 'tinyint', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -850,8 +850,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'f1', 1, null, 'YES', 'float', null, null, 12, null, null, null, null, 'float', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -875,8 +875,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'f1', 1, null, 'YES', 'decimal', null, null, 10, 0, null, null, null, 'decimal(10,0)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -900,8 +900,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'c1', 1, null, 'YES', 'char', 1, 4, null, null, null, 'utf8mb4', 'utf8mb4_general_ci', 'char(1)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -921,8 +921,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'c1', 1, null, 'YES', 'varchar', 255, 1020, null, null, null, 'utf8mb4', 'utf8mb4_general_ci', 'varchar(255)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -944,8 +944,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'c1', 1, null, 'YES', 'char', 1, 3, null, null, null, 'utf8', 'utf8_general_ci', 'char(1)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -969,8 +969,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'c1', 1, null, 'YES', 'varchar', 255, 765, null, null, null, 'utf8', 'utf8_general_ci', 'varchar(255)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -992,8 +992,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'c1', 1, null, 'YES', 'varchar', 255, 765, null, null, null, 'utf8', 'utf8_general_ci', 'varchar(255)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1015,8 +1015,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 't1', 1, null, 'YES', 'tinytext', 255, 255, null, null, null, 'utf8mb4', 'utf8mb4_general_ci', 'tinytext', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1040,8 +1040,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'e', 1, null, 'YES', 'enum', 1, 4, null, null, null, 'utf8mb4', 'utf8mb4_general_ci', 'enum(''a'',''b'',''c'')', '', '', 'select,insert,update,references', '', '', null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
@@ -1059,8 +1059,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'd', 1, null, 'YES', 'date', null, null, null, null, null, null, null, 'date', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1086,8 +1086,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'b', 1, null, 'YES', 'binary', 1, 1, null, null, null, null, null, 'binary(1)', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1107,8 +1107,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'b1', 1, null, 'YES', 'tinyblob', 255, 255, null, null, null, null, null, 'tinyblob', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1132,8 +1132,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'g1', 1, null, 'YES', 'geometry', null, null, null, null, null, null, null, 'geometry', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1157,8 +1157,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'g1', 1, null, 'YES', 'multipoint', null, null, null, null, null, null, null, 'multipoint', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1180,8 +1180,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'g1', 1, null, 'YES', 'geomcollection', null, null, null, null, null, null, null, 'geomcollection', '', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
@@ -1201,8 +1201,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$this->assertExecutedInformationSchemaQueries(
 			array(
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`)'
-					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_tables` (`table_schema`, `table_name`, `table_type`, `engine`, `row_format`, `table_collation`, `table_comment`)'
+					. " VALUES ('wp', 't', 'BASE TABLE', 'InnoDB', 'Dynamic', 'utf8mb4_general_ci', '')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'id', 1, null, 'NO', 'bigint', null, null, 20, 0, null, null, null, 'bigint unsigned', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",

--- a/wp-includes/mysql/class-wp-mysql-lexer.php
+++ b/wp-includes/mysql/class-wp-mysql-lexer.php
@@ -2130,7 +2130,7 @@ class WP_MySQL_Lexer {
 	 *
 	 * @var int
 	 */
-	private $sql_modes;
+	private $sql_modes = 0;
 
 	/**
 	 * How many bytes from the original SQL payload have been read and tokenized.
@@ -2181,16 +2181,28 @@ class WP_MySQL_Lexer {
 	/**
 	 * @param string $sql The SQL payload to tokenize.
 	 * @param int $mysql_version The version of the MySQL server that the SQL payload is intended for.
-	 * @param int $sql_modes The SQL modes that should be considered active during tokenization.
+	 * @param string[] $sql_modes The SQL modes that should be considered active during tokenization.
 	 */
 	public function __construct(
 		string $sql,
 		int $mysql_version = 80038,
-		int $sql_modes = 0
+		array $sql_modes = array()
 	) {
 		$this->sql           = $sql;
 		$this->mysql_version = $mysql_version;
-		$this->sql_modes     = $sql_modes;
+
+		foreach ( $sql_modes as $sql_mode ) {
+			$sql_mode = strtoupper( $sql_mode );
+			if ( 'HIGH_NOT_PRECEDENCE' === $sql_mode ) {
+				$this->sql_modes |= self::SQL_MODE_HIGH_NOT_PRECEDENCE;
+			} elseif ( 'PIPES_AS_CONCAT' === $sql_mode ) {
+				$this->sql_modes |= self::SQL_MODE_PIPES_AS_CONCAT;
+			} elseif ( 'IGNORE_SPACE' === $sql_mode ) {
+				$this->sql_modes |= self::SQL_MODE_IGNORE_SPACE;
+			} elseif ( 'NO_BACKSLASH_ESCAPES' === $sql_mode ) {
+				$this->sql_modes |= self::SQL_MODE_NO_BACKSLASH_ESCAPES;
+			}
+		}
 	}
 
 	/**
@@ -2251,7 +2263,8 @@ class WP_MySQL_Lexer {
 			$this->token_type,
 			$this->token_starts_at,
 			$this->bytes_already_read - $this->token_starts_at,
-			$this->sql
+			$this->sql,
+			$this->is_sql_mode_active( self::SQL_MODE_NO_BACKSLASH_ESCAPES )
 		);
 	}
 

--- a/wp-includes/mysql/class-wp-mysql-token.php
+++ b/wp-includes/mysql/class-wp-mysql-token.php
@@ -8,6 +8,33 @@
  */
 class WP_MySQL_Token extends WP_Parser_Token {
 	/**
+	 * Whether the NO_BACKSLASH_ESCAPES SQL mode is enabled.
+	 *
+	 * @var bool
+	 */
+	private $sql_mode_no_backslash_escapes_enabled;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int    $id                                    Token type.
+	 * @param int    $start                                 Byte offset in the input where the token begins.
+	 * @param int    $length                                Byte length of the token in the input.
+	 * @param string $input                                 Input bytes from which the token was parsed.
+	 * @param bool   $sql_mode_no_backslash_escapes_enabled Whether the NO_BACKSLASH_ESCAPES SQL mode is enabled.
+	 */
+	public function __construct(
+		int $id,
+		int $start,
+		int $length,
+		string $input,
+		bool $sql_mode_no_backslash_escapes_enabled
+	) {
+		parent::__construct( $id, $start, $length, $input );
+		$this->sql_mode_no_backslash_escapes_enabled = $sql_mode_no_backslash_escapes_enabled;
+	}
+
+	/**
 	 * Get the name of the token.
 	 *
 	 * This method is intended to be used only for testing and debugging purposes,
@@ -40,6 +67,15 @@ class WP_MySQL_Token extends WP_Parser_Token {
 			$quote = $value[0];
 			$value = substr( $value, 1, -1 );
 
+			/*
+			 * When the NO_BACKSLASH_ESCAPES SQL mode is enabled, we only need to
+			 * handle escaped bounding quotes, as the other characters preserve
+			 * their literal values.
+			 */
+			if ( $this->sql_mode_no_backslash_escapes_enabled ) {
+				return str_replace( $quote . $quote, $quote, $value );
+			}
+
 			/**
 			 * Unescape MySQL escape sequences.
 			 *
@@ -57,8 +93,6 @@ class WP_MySQL_Token extends WP_Parser_Token {
 			 *
 			 * Despite looking similar, these rules are different from the C-style
 			 * string escaping, so we cannot use "strip(c)slashes()" in this case.
-			 *
-			 * @TODO: Handle NO_BACKSLASH_ESCAPES SQL mode.
 			 *
 			 * See: https://dev.mysql.com/doc/refman/8.4/en/string-literals.html
 			 */

--- a/wp-includes/mysql/class-wp-mysql-token.php
+++ b/wp-includes/mysql/class-wp-mysql-token.php
@@ -62,18 +62,19 @@ class WP_MySQL_Token extends WP_Parser_Token {
 			 *
 			 * See: https://dev.mysql.com/doc/refman/8.4/en/string-literals.html
 			 */
+			$backslash    = chr( 92 );
 			$replacements = array(
 				/*
 				 * MySQL special character escape sequences.
 				 */
-				'\0'   => chr( 0 ),  // An ASCII NULL (X'00') character.
-				"\'"   => "'",       // A single quote (') character.
-				'\"'   => '"',       // A double quote (") character.
-				'\b'   => chr( 8 ),  // A backspace character.
-				'\n'   => "\n",      // A newline (linefeed) character.
-				'\r'   => "\r",      // A carriage return character.
-				'\t'   => "\t",      // A tab character.
-				'\Z'   => chr( 26 ), // An ASCII 26 (Control+Z) character.
+				( $backslash . '0' ) => chr( 0 ),  // An ASCII NULL character (\0).
+				( $backslash . "'" ) => chr( 39 ), // A single quote character (').
+				( $backslash . '"' ) => chr( 34 ), // A double quote character (").
+				( $backslash . 'b' ) => chr( 8 ),  // A backspace character.
+				( $backslash . 'n' ) => chr( 10 ), // A newline (linefeed) character (\n).
+				( $backslash . 'r' ) => chr( 13 ), // A carriage return character (\r).
+				( $backslash . 't' ) => chr( 9 ),  // A tab character (\t).
+				( $backslash . 'Z' ) => chr( 26 ), // An ASCII 26 (Control+Z) character.
 
 				/*
 				 * Normalize escaping of "%" and "_" characters.
@@ -92,8 +93,8 @@ class WP_MySQL_Token extends WP_Parser_Token {
 				 *   > of pattern-matching contexts, they evaluate to the strings \% and
 				 *   > \_, not to % and _.
 				 */
-				'\%'   => '\\\\%',
-				'\_'   => '\\\\_',
+				( $backslash . '%' ) => $backslash . $backslash . '%',
+				( $backslash . '_' ) => $backslash . $backslash . '_',
 
 				/*
 				 * Preserve a double backslash as-is, so that the trailing backslash
@@ -102,13 +103,13 @@ class WP_MySQL_Token extends WP_Parser_Token {
 				 * Resolving "\\" to "\" will be handled in the next step, where all
 				 * other backslash-prefixed characters resolve to their literal values.
 				 */
-				'\\\\' => '\\\\',
+				( $backslash . $backslash )
+					=> $backslash . $backslash,
 
 				/*
 				 * The bounding quotes can also be escaped by being doubled.
 				 */
-				$quote . $quote
-					=> $quote,
+				( $quote . $quote )  => $quote,
 			);
 
 			/*
@@ -127,7 +128,8 @@ class WP_MySQL_Token extends WP_Parser_Token {
 			 * A backslash with any other character represents the character itself.
 			 * That is, \x evaluates to x, \\ evaluates to \, and \🙂 evaluates to 🙂.
 			 */
-			$value = preg_replace( '/\\\\(.)/u', '$1', $value );
+			$preg_quoted_backslash = preg_quote( $backslash );
+			$value                 = preg_replace( "/$preg_quoted_backslash(.)/u", '$1', $value );
 		}
 		return $value;
 	}

--- a/wp-includes/mysql/class-wp-mysql-token.php
+++ b/wp-includes/mysql/class-wp-mysql-token.php
@@ -25,6 +25,114 @@ class WP_MySQL_Token extends WP_Parser_Token {
 	}
 
 	/**
+	 * Get the real unquoted value of the token.
+	 *
+	 * @return string The token value.
+	 */
+	public function get_value(): string {
+		$value = $this->get_bytes();
+		if (
+			WP_MySQL_Lexer::SINGLE_QUOTED_TEXT === $this->id
+			|| WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT === $this->id
+			|| WP_MySQL_Lexer::BACK_TICK_QUOTED_ID === $this->id
+		) {
+			// Remove bounding quotes.
+			$quote = $value[0];
+			$value = substr( $value, 1, -1 );
+
+			/**
+			 * Unescape MySQL escape sequences.
+			 *
+			 * MySQL string literals use backslash as an escape character, and
+			 * the string bounding quotes can also be escaped by being doubled.
+			 *
+			 * The escaping is done according to the following rules:
+			 *
+			 *   1. Some special character escape sequences are recognized.
+			 *      For example, "\n" is a newline character, "\0" is ASCII NULL.
+			 *   2. A specific treatment is applied to "\%" and "\_" sequences.
+			 *      This is due to their special meaning for pattern matching.
+			 *   3. Other backslash-prefixed characters resolve to their literal
+			 *      values. For example, "\x" represents "x", "\\" represents "\".
+			 *
+			 * Despite looking similar, these rules are different from the C-style
+			 * string escaping, so we cannot use "strip(c)slashes()" in this case.
+			 *
+			 * @TODO: Handle NO_BACKSLASH_ESCAPES SQL mode.
+			 *
+			 * See: https://dev.mysql.com/doc/refman/8.4/en/string-literals.html
+			 */
+			$replacements = array(
+				/*
+				 * MySQL special character escape sequences.
+				 */
+				'\0'   => chr( 0 ),  // An ASCII NULL (X'00') character.
+				"\'"   => "'",       // A single quote (') character.
+				'\"'   => '"',       // A double quote (") character.
+				'\b'   => chr( 8 ),  // A backspace character.
+				'\n'   => "\n",      // A newline (linefeed) character.
+				'\r'   => "\r",      // A carriage return character.
+				'\t'   => "\t",      // A tab character.
+				'\Z'   => chr( 26 ), // An ASCII 26 (Control+Z) character.
+
+				/*
+				 * Normalize escaping of "%" and "_" characters.
+				 *
+				 * MySQL has unusual handling for "\%" and "\_" in all string literals.
+				 * While other sequences follow the C-style escaping ("\?" is "?", etc.),
+				 * "\%" resolves to "\%" and "\_" resolves to "\_" (unlike in C strings).
+				 *
+				 * This means that "\%" behaves like "\\%", and "\_" behaves like "\\_".
+				 * To preserve this behavior, we need to add a second backslash here.
+				 *
+				 * From https://dev.mysql.com/doc/refman/8.4/en/string-literals.html:
+				 *   > The \% and \_ sequences are used to search for literal instances
+				 *   > of % and _ in pattern-matching contexts where they would otherwise
+				 *   > be interpreted as wildcard characters. If you use \% or \_ outside
+				 *   > of pattern-matching contexts, they evaluate to the strings \% and
+				 *   > \_, not to % and _.
+				 */
+				'\%'   => '\\\\%',
+				'\_'   => '\\\\_',
+
+				/*
+				 * Preserve a double backslash as-is, so that the trailing backslash
+				 * is not consumed as the beginning of an escape sequence like "\n".
+				 *
+				 * Resolving "\\" to "\" will be handled in the next step, where all
+				 * other backslash-prefixed characters resolve to their literal values.
+				 */
+				'\\\\' => '\\\\',
+
+				/*
+				 * The bounding quotes can also be escaped by being doubled.
+				 */
+				$quote . $quote
+					=> $quote,
+			);
+
+			/*
+			 * Apply the replacements.
+			 *
+			 * It is important to use "strtr()" and not "str_replace()", because
+			 * "str_replace()" applies replacements one after another, modifying
+			 * intermediate changes rather than just the original string:
+			 *
+			 *   - str_replace( [ 'a', 'b' ], [ 'b', 'c' ], 'ab' ); // 'cc' (bad)
+			 *   - strtr( 'ab', [ 'a' => 'b', 'b' => 'c' ] );       // 'bc' (good)
+			 */
+			$value = strtr( $value, $replacements );
+
+			/*
+			 * A backslash with any other character represents the character itself.
+			 * That is, \x evaluates to x, \\ evaluates to \, and \🙂 evaluates to 🙂.
+			 */
+			$value = preg_replace( '/\\\\(.)/u', '$1', $value );
+		}
+		return $value;
+	}
+
+	/**
 	 * Get the token representation as a string.
 	 *
 	 * This method is intended to be used only for testing and debugging purposes,

--- a/wp-includes/parser/class-wp-parser-token.php
+++ b/wp-includes/parser/class-wp-parser-token.php
@@ -58,11 +58,20 @@ class WP_Parser_Token {
 	}
 
 	/**
-	 * Get the token value as raw bytes from the input.
+	 * Get the raw bytes of the token from the input.
+	 *
+	 * @return string The token bytes.
+	 */
+	public function get_bytes(): string {
+		return substr( $this->input, $this->start, $this->length );
+	}
+
+	/**
+	 * Get the real unquoted value of the token.
 	 *
 	 * @return string The token value.
 	 */
 	public function get_value(): string {
-		return substr( $this->input, $this->start, $this->length );
+		return $this->get_bytes();
 	}
 }

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -691,7 +691,11 @@ class WP_SQLite_Driver {
 	 * @return WP_MySQL_Parser        A parser initialized for the MySQL query.
 	 */
 	public function create_parser( string $query ): WP_MySQL_Parser {
-		$lexer  = new WP_MySQL_Lexer( $query );
+		$lexer  = new WP_MySQL_Lexer(
+			$query,
+			80038,
+			$this->active_sql_modes
+		);
 		$tokens = $lexer->remaining_tokens();
 		return new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
 	}
@@ -2508,7 +2512,11 @@ class WP_SQLite_Driver {
 		 * We'll probably need to overload the like() function:
 		 *   https://www.sqlite.org/lang_corefunc.html#like
 		 */
-		return $this->translate_sequence( $node->get_children() ) . " ESCAPE '\\'";
+		$statement = $this->translate_sequence( $node->get_children() );
+		if ( $this->is_sql_mode_active( 'NO_BACKSLASH_ESCAPES' ) ) {
+			return $statement;
+		}
+		return $statement . " ESCAPE '\\'";
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3402,6 +3402,13 @@ class WP_SQLite_Driver {
 				$sql .= ' ON UPDATE CURRENT_TIMESTAMP';
 			}
 
+			if ( '' !== $column['COLUMN_COMMENT'] ) {
+				$sql .= sprintf(
+					' COMMENT %s',
+					$this->quote_mysql_utf8_string_literal( $column['COLUMN_COMMENT'] )
+				);
+			}
+
 			$rows[] = $sql;
 		}
 
@@ -3411,8 +3418,8 @@ class WP_SQLite_Driver {
 			$info = $constraint[1];
 
 			if ( 'PRIMARY' === $info['INDEX_NAME'] ) {
-				$sql    = '  PRIMARY KEY (';
-				$sql   .= implode(
+				$sql  = '  PRIMARY KEY (';
+				$sql .= implode(
 					', ',
 					array_map(
 						function ( $column ) {
@@ -3421,8 +3428,7 @@ class WP_SQLite_Driver {
 						$constraint
 					)
 				);
-				$sql   .= ')';
-				$rows[] = $sql;
+				$sql .= ')';
 			} else {
 				$is_unique = '0' === $info['NON_UNIQUE'];
 
@@ -3448,9 +3454,16 @@ class WP_SQLite_Driver {
 					)
 				);
 				$sql .= ')';
-
-				$rows[] = $sql;
 			}
+
+			if ( '' !== $info['INDEX_COMMENT'] ) {
+				$sql .= sprintf(
+					' COMMENT %s',
+					$this->quote_mysql_utf8_string_literal( $info['INDEX_COMMENT'] )
+				);
+			}
+
+			$rows[] = $sql;
 		}
 
 		// 5. Compose the CREATE TABLE statement.
@@ -3467,6 +3480,12 @@ class WP_SQLite_Driver {
 		$sql .= sprintf( ' ENGINE=%s', $table_info['ENGINE'] );
 		$sql .= sprintf( ' DEFAULT CHARSET=%s', $charset );
 		$sql .= sprintf( ' COLLATE=%s', $collation );
+		if ( '' !== $table_info['TABLE_COMMENT'] ) {
+			$sql .= sprintf(
+				' COMMENT=%s',
+				$this->quote_mysql_utf8_string_literal( $table_info['TABLE_COMMENT'] )
+			);
+		}
 		return $sql;
 	}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3560,7 +3560,7 @@ class WP_SQLite_Driver {
 	}
 
 	/**
-	 * Format a MySQL string literal for output in a CREATE TABLE statement.
+	 * Format a MySQL UTF-8 string literal for output in a CREATE TABLE statement.
 	 *
 	 * We expect UTF-8 strings coming from SQLite. The only characters that must
 	 * be escaped in a single-quoted string for a UTF-8 MySQL dump are ' and \.
@@ -3580,10 +3580,10 @@ class WP_SQLite_Driver {
 	 * TODO: We may consider stripping invalid UTF-8 characters, but that's likely
 	 *       to be a bigger project, as these can appear also in other contexts.
 	 *
-	 * @param  string $literal The string literal to escape.
-	 * @return string          The escaped string literal.
+	 * @param  string $utf8_literal The UTF-8 string literal to escape.
+	 * @return string               The escaped string literal.
 	 */
-	private function quote_mysql_utf8_string_literal( string $literal ): string {
+	private function quote_mysql_utf8_string_literal( string $utf8_literal ): string {
 		/*
 		 * We can't use "addcslashes()" here, because it has an unusual handling
 		 * of the ASCII NULL character, escaping it to "\000" instead of "\0".
@@ -3595,14 +3595,15 @@ class WP_SQLite_Driver {
 		 *   - str_replace( [ 'a', 'b' ], [ 'b', 'c' ], 'ab' ); // 'cc' (bad)
 		 *   - strtr( 'ab', [ 'a' => 'b', 'b' => 'c' ] );       // 'bc' (good)
 		 */
+		$backslash    = chr( 92 );
 		$replacements = array(
-			"'"  => "''",
-			'\\' => '\\\\',
-			"\0" => '\0',
-			"\n" => '\n',
-			"\r" => '\r',
+			"'"        => "''",                    // A single quote character (').
+			$backslash => $backslash . $backslash, // A backslash character (\).
+			chr( 0 )   => $backslash . '0',        // An ASCII NULL character (\0).
+			chr( 10 )  => $backslash . 'n',        // A newline (linefeed) character (\n).
+			chr( 13 )  => $backslash . 'r',        // A carriage return character (\r).
 		);
-		return "'" . strtr( $literal, $replacements ) . "'";
+		return "'" . strtr( $utf8_literal, $replacements ) . "'";
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2294,45 +2294,7 @@ class WP_SQLite_Driver {
 	 */
 	private function translate_string_literal( WP_Parser_Node $node ): string {
 		$token = $node->get_first_child_token();
-
-		/*
-		 * 1. Remove bounding quotes.
-		 */
-		$quote = $token->get_value()[0];
-		$value = substr( $token->get_value(), 1, -1 );
-
-		/*
-		 * 2. Normalize escaping of "%" and "_" characters.
-		 *
-		 * MySQL has unusual handling for "\%" and "\_" in all string literals.
-		 * While other sequences follow the C-style escaping ("\?" is "?", etc.),
-		 * "\%" resolves to "\%" and "\_" resolves to "\_" (unlike in C strings).
-		 *
-		 * This means that "\%" behaves like "\\%", and "\_" behaves like "\\_".
-		 * To preserve this behavior, we need to add a second backslash in cases
-		 * where only one is used. To do so correctly, we need to:
-		 *
-		 *  1. Skip all double backslash patterns (as "\\" resolves to "\").
-		 *  2. Add an extra backslash when "\%" or "\_" follows right after.
-		 *
-		 * This may be related to: https://bugs.mysql.com/bug.php?id=84118
-		 */
-		$value = preg_replace( '/(^|[^\\\\](?:\\\\{2}))*(\\\\[%_])/', '$1\\\\$2', $value );
-
-		/*
-		 * 3. Unescape quotes within the string.
-		 */
-		$value = str_replace( $quote . $quote, $quote, $value );
-
-		/*
-		 * 4. Unescape C-style escape sequences.
-		 *
-		 * MySQL string literals are represented using C-style encoded strings,
-		 * but SQLite doesn't support such escaping.
-		 *
-		 * @TODO: Handle NO_BACKSLASH_ESCAPES SQL mode.
-		 */
-		$value = stripcslashes( $value );
+		$value = $token->get_value();
 
 		/*
 		 * 5. Translate datetime literals.
@@ -2383,17 +2345,7 @@ class WP_SQLite_Driver {
 	 */
 	private function translate_pure_identifier( WP_Parser_Node $node ): string {
 		$token = $node->get_first_child_token();
-
-		if ( WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT === $token->id ) {
-			$value = substr( $token->get_value(), 1, -1 );
-			$value = str_replace( '""', '"', $value );
-		} elseif ( WP_MySQL_Lexer::BACK_TICK_QUOTED_ID === $token->id ) {
-			$value = substr( $token->get_value(), 1, -1 );
-			$value = str_replace( '``', '`', $value );
-		} else {
-			$value = $token->get_value();
-		}
-
+		$value = $token->get_value();
 		return '`' . str_replace( '`', '``', $value ) . '`';
 	}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3392,7 +3392,7 @@ class WP_SQLite_Driver {
 			) {
 				$sql .= ' DEFAULT CURRENT_TIMESTAMP';
 			} elseif ( null !== $column['COLUMN_DEFAULT'] ) {
-				$sql .= ' DEFAULT ' . $this->connection->quote( $column['COLUMN_DEFAULT'] );
+				$sql .= ' DEFAULT ' . $this->quote_mysql_utf8_string_literal( $column['COLUMN_DEFAULT'] );
 			} elseif ( 'YES' === $column['IS_NULLABLE'] ) {
 				$sql .= ' DEFAULT NULL';
 			}
@@ -3528,7 +3528,6 @@ class WP_SQLite_Driver {
 		return $this->connection->quote_identifier( $unquoted_identifier );
 	}
 
-
 	/**
 	 * Quote a MySQL identifier.
 	 *
@@ -3539,6 +3538,52 @@ class WP_SQLite_Driver {
 	 */
 	private function quote_mysql_identifier( string $unquoted_identifier ): string {
 		return '`' . str_replace( '`', '``', $unquoted_identifier ) . '`';
+	}
+
+	/**
+	 * Format a MySQL string literal for output in a CREATE TABLE statement.
+	 *
+	 * We expect UTF-8 strings coming from SQLite. The only characters that must
+	 * be escaped in a single-quoted string for a UTF-8 MySQL dump are ' and \.
+	 *
+	 * MySQL SHOW CREATE TABLE command additionally escapes "\0", "\n", and "\r",
+	 * for the mysql CLI, logs, and better readability. This applies to column
+	 * default values, and table, column, and index comments. Other values, such
+	 * as identifiers, don't have these extra characters escaped in the output.
+	 *
+	 * See:
+	 *  - https://github.com/mysql/mysql-server/blob/ff05628a530696bc6851ba6540ac250c7a059aa7/sql/sql_show.cc#L1799
+	 *  - https://github.com/mysql/mysql-server/blob/ff05628a530696bc6851ba6540ac250c7a059aa7/sql/table.cc#L3525
+	 *
+	 * Unfortunately, SQLite doesn't validate the UTF-8 encoding, so other byte
+	 * sequences may come from SQLite as well: https://www.sqlite.org/invalidutf.html
+	 *
+	 * TODO: We may consider stripping invalid UTF-8 characters, but that's likely
+	 *       to be a bigger project, as these can appear also in other contexts.
+	 *
+	 * @param  string $literal The string literal to escape.
+	 * @return string          The escaped string literal.
+	 */
+	private function quote_mysql_utf8_string_literal( string $literal ): string {
+		/*
+		 * We can't use "addcslashes()" here, because it has an unusual handling
+		 * of the ASCII NULL character, escaping it to "\000" instead of "\0".
+		 *
+		 * It is important to use "strtr()" and not "str_replace()", because
+		 * "str_replace()" applies replacements one after another, modifying
+		 * intermediate changes rather than just the original string:
+		 *
+		 *   - str_replace( [ 'a', 'b' ], [ 'b', 'c' ], 'ab' ); // 'cc' (bad)
+		 *   - strtr( 'ab', [ 'a' => 'b', 'b' => 'c' ] );       // 'bc' (good)
+		 */
+		$replacements = array(
+			"'"  => "''",
+			'\\' => '\\\\',
+			"\0" => '\0',
+			"\n" => '\n',
+			"\r" => '\r',
+		);
+		return "'" . strtr( $literal, $replacements ) . "'";
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -1911,19 +1911,6 @@ class WP_SQLite_Information_Schema_Builder {
 		foreach ( $node->get_children() as $child ) {
 			if ( $child instanceof WP_Parser_Node ) {
 				$value = $this->get_value( $child );
-			} elseif ( WP_MySQL_Lexer::BACK_TICK_QUOTED_ID === $child->id ) {
-				$value = substr( $child->get_value(), 1, -1 );
-				$value = str_replace( '``', '`', $value );
-			} elseif ( WP_MySQL_Lexer::SINGLE_QUOTED_TEXT === $child->id ) {
-				$value = $child->get_value();
-				$value = substr( $value, 1, -1 );
-				$value = str_replace( "\'", "'", $value );
-				$value = str_replace( "''", "'", $value );
-			} elseif ( WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT === $child->id ) {
-				$value = $child->get_value();
-				$value = substr( $value, 1, -1 );
-				$value = str_replace( '\"', '"', $value );
-				$value = str_replace( '""', '"', $value );
 			} else {
 				$value = $child->get_value();
 			}

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -455,6 +455,7 @@ class WP_SQLite_Information_Schema_Builder {
 		$table_engine     = $this->get_table_engine( $node );
 		$table_row_format = 'MyISAM' === $table_engine ? 'Fixed' : 'Dynamic';
 		$table_collation  = $this->get_table_collation( $node );
+		$table_comment    = $this->get_table_comment( $node );
 
 		/*
 		 * When creating a temporary table:
@@ -476,6 +477,7 @@ class WP_SQLite_Information_Schema_Builder {
 			'engine'          => $table_engine,
 			'row_format'      => $table_row_format,
 			'table_collation' => $table_collation,
+			'table_comment'   => $table_comment,
 		);
 
 		try {
@@ -957,11 +959,11 @@ class WP_SQLite_Information_Schema_Builder {
 		$first_column_type  = $column_info_map[ $first_column_name ]['DATA_TYPE'] ?? null;
 		$has_spatial_column = null !== $first_column_type && $this->is_spatial_data_type( $first_column_type );
 
-		$non_unique = $this->get_index_non_unique( $keyword );
-		$index_name = $this->get_index_name( $node );
-		$index_type = $this->get_index_type( $node, $keyword, $has_spatial_column );
-
-		$seq_in_index = 1;
+		$non_unique    = $this->get_index_non_unique( $keyword );
+		$index_name    = $this->get_index_name( $node );
+		$index_type    = $this->get_index_type( $node, $keyword, $has_spatial_column );
+		$index_comment = $this->get_index_comment( $node );
+		$seq_in_index  = 1;
 		foreach ( $key_parts as $i => $key_part ) {
 			$column_name = $key_part_column_names[ $i ];
 			$collation   = $this->get_index_column_collation( $key_part, $index_type );
@@ -995,7 +997,7 @@ class WP_SQLite_Information_Schema_Builder {
 				'nullable'      => $nullable,
 				'index_type'    => $index_type,
 				'comment'       => '', // not implemented
-				'index_comment' => '', // @TODO
+				'index_comment' => $index_comment,
 				'is_visible'    => 'YES', // @TODO: Save actual visibility value.
 				'expression'    => null, // @TODO
 			);
@@ -1188,6 +1190,21 @@ class WP_SQLite_Information_Schema_Builder {
 			return 'utf8mb4_general_ci';
 		}
 		return strtolower( $this->get_value( $collate_node ) );
+	}
+
+	/**
+	 * Extract table comment from the "createStatement" AST node.
+	 *
+	 * @param  WP_Parser_Node $node The "createStatement" AST node with "createTable" child.
+	 * @return string               The table comment as stored in information schema.
+	 */
+	private function get_table_comment( WP_Parser_Node $node ): string {
+		foreach ( $node->get_descendant_nodes( 'createTableOption' ) as $attr ) {
+			if ( $attr->has_child_token( WP_MySQL_Lexer::COMMENT_SYMBOL ) ) {
+				return $this->get_value( $attr->get_first_child_node( 'textStringLiteral' ) );
+			}
+		}
+		return '';
 	}
 
 	/**
@@ -1809,6 +1826,21 @@ class WP_SQLite_Information_Schema_Builder {
 		}
 
 		return 'BTREE';
+	}
+
+	/**
+	 * Extract index comment from the "tableConstraintDef" AST node.
+	 *
+	 * @param  WP_Parser_Node $node The "tableConstraintDef" AST node.
+	 * @return string               The index comment as stored in information schema.
+	 */
+	public function get_index_comment( WP_Parser_Node $node ): string {
+		foreach ( $node->get_descendant_nodes( 'commonIndexOption' ) as $attr ) {
+			if ( $attr->has_child_token( WP_MySQL_Lexer::COMMENT_SYMBOL ) ) {
+				return $this->get_value( $attr->get_first_child_node( 'textLiteral' ) );
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php
@@ -664,25 +664,26 @@ class WP_SQLite_Information_Schema_Reconstructor {
 	}
 
 	/**
-	 * Format a MySQL string literal for output in a CREATE TABLE statement.
+	 * Format a MySQL UTF-8 string literal for output in a CREATE TABLE statement.
 	 *
 	 * See WP_SQLite_Driver::quote_mysql_utf8_string_literal().
 	 *
 	 * TODO: This is a copy of WP_SQLite_Driver::quote_mysql_utf8_string_literal().
 	 *       We may consider extracing it to reusable MySQL helpers.
 	 *
-	 * @param  string $literal The string literal to escape.
-	 * @return string          The escaped string literal.
+	 * @param  string $utf8_literal The UTF-8 string literal to escape.
+	 * @return string               The escaped string literal.
 	 */
-	private function quote_mysql_utf8_string_literal( string $literal ): string {
+	private function quote_mysql_utf8_string_literal( string $utf8_literal ): string {
+		$backslash    = chr( 92 );
 		$replacements = array(
-			"'"  => "''",
-			'\\' => '\\\\',
-			"\0" => '\0',
-			"\n" => '\n',
-			"\r" => '\r',
+			"'"        => "''",                    // A single quote character (').
+			$backslash => $backslash . $backslash, // A backslash character (\).
+			chr( 0 )   => $backslash . '0',        // An ASCII NULL character (\0).
+			chr( 10 )  => $backslash . 'n',        // A newline (linefeed) character (\n).
+			chr( 13 )  => $backslash . 'r',        // A carriage return character (\r).
 		);
-		return "'" . strtr( $literal, $replacements ) . "'";
+		return "'" . strtr( $utf8_literal, $replacements ) . "'";
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php
@@ -517,7 +517,7 @@ class WP_SQLite_Information_Schema_Reconstructor {
 		if ( '"' === $first_byte || "'" === $first_byte || '`' === $first_byte ) {
 			$value = substr( $default_value, 1, -1 );
 			$value = str_replace( $first_byte . $first_byte, $first_byte, $value );
-			return $this->format_mysql_string_literal( $value );
+			return $this->quote_mysql_utf8_string_literal( $value );
 		}
 
 		// Normalize the default value for easier comparison.
@@ -564,7 +564,7 @@ class WP_SQLite_Information_Schema_Reconstructor {
 		}
 
 		// Unquoted string literal. E.g.: abc
-		return $this->format_mysql_string_literal( $default_value );
+		return $this->quote_mysql_utf8_string_literal( $default_value );
 	}
 
 	/**
@@ -664,32 +664,25 @@ class WP_SQLite_Information_Schema_Reconstructor {
 	}
 
 	/**
-	 * Format a MySQL string literal for output in a SHOW statement.
+	 * Format a MySQL string literal for output in a CREATE TABLE statement.
 	 *
-	 * We expect UTF-8 strings coming from SQLite. The only characters that need
-	 * to be escaped in a single-quoted string for a UTF-8 MySQL dump are ' and \.
+	 * See WP_SQLite_Driver::quote_mysql_utf8_string_literal().
 	 *
-	 * MySQL's SHOW command also escapes \0 (for the mysql CLI), \n (for logs and
-	 * readability), and \r (for readability). Let's these characters as well.
-	 *
-	 * See:
-	 *  - https://github.com/mysql/mysql-server/blob/ff05628a530696bc6851ba6540ac250c7a059aa7/sql/sql_show.cc#L1799
-	 *  - https://github.com/mysql/mysql-server/blob/ff05628a530696bc6851ba6540ac250c7a059aa7/sql/table.cc#L3525
-	 *
-	 * Unfortunately, SQLite doesn't validate the UTF-8 encoding of strings, so
-	 * other byte sequences may come from SQLite as well.
-	 *
-	 * See: https://www.sqlite.org/invalidutf.html
-	 *
-	 * TODO: We may consider stripping invalid UTF-8 characters, but that's likely
-	 *       to be a bigger project, as these can appear also in other contexts.
+	 * TODO: This is a copy of WP_SQLite_Driver::quote_mysql_utf8_string_literal().
+	 *       We may consider extracing it to reusable MySQL helpers.
 	 *
 	 * @param  string $literal The string literal to escape.
 	 * @return string          The escaped string literal.
 	 */
-	private function format_mysql_string_literal( string $literal ): string {
-		$value = addcslashes( $literal, "\0\n\r\\" );
-		return "'" . str_replace( "'", "''", $value ) . "'";
+	private function quote_mysql_utf8_string_literal( string $literal ): string {
+		$replacements = array(
+			"'"  => "''",
+			'\\' => '\\\\',
+			"\0" => '\0',
+			"\n" => '\n',
+			"\r" => '\r',
+		);
+		return "'" . strtr( $literal, $replacements ) . "'";
 	}
 
 	/**


### PR DESCRIPTION
The [translate_string_literal](https://github.com/Automattic/sqlite-database-integration/blob/767d246522691c62f3e8ee316092e0cd781cede2/wp-includes/sqlite-ast/class-wp-sqlite-driver.php#L2273) logic in the SQLite driver that handles "unescaping" (interpreting) of MySQL escape sequences is only applied to a `textStringLiteral` AST node. It turns out, the same logic is needed in [`translate_pure_identifier`](https://github.com/Automattic/sqlite-database-integration/blob/767d246522691c62f3e8ee316092e0cd781cede2/wp-includes/sqlite-ast/class-wp-sqlite-driver.php#L2273), or, in other words, also for `WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT` and `WP_MySQL_Lexer::BACK_TICK_QUOTED_ID` tokens.

Therefore, it's probably better to move this logic to the tokenization phase and make token instances return the correct unquoted token values.

Surfaced in https://github.com/Automattic/sqlite-database-integration/pull/42.