### PR TITLE
Update minimum required PHP version to 7.2

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        # NOTE: There does not appear to be a single phpunit version that supports all
-        # PHP versions tested here. For now, we are removing PHP 7.0. and 7.1 tests
-        # in order to run a single phpunit version for PHP 7.2 and up.
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     with:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"issues": "https://github.com/wordpress/sqlite-database-integration/issues"
 	},
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.2",
 		"ext-pdo": "*",
 		"ext-pdo_sqlite": "*"
 	},

--- a/load.php
+++ b/load.php
@@ -4,7 +4,7 @@
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
  * Version: 2.1.17-alpha
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * Textdomain: sqlite-database-integration
  *
  * This feature plugin allows WordPress to use SQLite instead of MySQL as its database.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgicak, bpayton, zaerl
 Requires at least: 6.4
 Tested up to:      6.6.1
-Requires PHP:      7.0
+Requires PHP:      7.2
 Stable tag:        2.1.17-alpha
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
The new SQLite driver already uses some features from PHP 7.2.

WordPress [recommends](https://wordpress.org/about/requirements/) PHP 7.4+ and requires PHP 7.2.24+.

Closes https://github.com/Automattic/sqlite-database-integration/issues/12.