### PR TITLE
New driver fixes from manual testing

### DIFF
--- a/.github/workflows/wp-tests-phpunit-run.js
+++ b/.github/workflows/wp-tests-phpunit-run.js
@@ -45,6 +45,7 @@ const expectedFailures = [
 	'Tests_Menu_Walker_Nav_Menu::test_start_el_with_empty_attributes with data set #6',
 	'Tests_Menu_Walker_Nav_Menu::test_start_el_with_empty_attributes with data set #7',
 	'Tests_Menu_wpNavMenu::test_wp_nav_menu_should_not_have_has_children_class_with_custom_depth',
+	'WP_Test_REST_Posts_Controller::test_get_items_orderby_modified_query',
 ];
 
 console.log( 'Running WordPress PHPUnit tests with expected failures tracking...' );

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4379,6 +4379,40 @@ QUERY
 		$this->assertSame( '', $result[0]->value );
 	}
 
+	public function testNonStrictModeWithDefaultCurrentTimestamp(): void {
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+		$this->assertQuery( 'CREATE TABLE t (id INT, value TIMESTAMP DEFAULT CURRENT_TIMESTAMP)' );
+
+		// INSERT without a value saves CURRENT_TIMESTAMP:
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (1)' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+		$this->assertRegExp( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result[0]->value );
+
+		// UPDATE with NULL saves NULL:
+		$this->assertQuery( 'UPDATE t SET value = NULL' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+		$this->assertNull( $result[0]->value );
+	}
+
+	public function testNonStrictModeWithDefaultCurrentTimestampNotNull(): void {
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+		$this->assertQuery( 'CREATE TABLE t (id INT, value TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)' );
+
+		// INSERT without a value saves CURRENT_TIMESTAMP:
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (1)' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+		$this->assertRegExp( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result[0]->value );
+
+		// UPDATE with NULL saves IMPLICIT DEFAULT:
+		$this->assertQuery( 'UPDATE t SET value = NULL' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+		$this->assertSame( '0000-00-00 00:00:00', $result[0]->value );
+	}
+
 	public function testNonStrictSqlModeWithNoListedColumns(): void {
 		$this->assertQuery( "SET SESSION sql_mode = ''" );
 

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4543,6 +4543,113 @@ QUERY
 		$this->assertSame( 'blue', $result[0]->color );
 	}
 
+	public function testNonStrictModeTypeCasting(): void {
+		$this->assertQuery(
+			"CREATE TABLE t (
+				col_int INT,
+				col_float FLOAT,
+				col_double DOUBLE,
+				col_decimal DECIMAL,
+				col_char CHAR(255),
+				col_varchar VARCHAR(255),
+				col_text TEXT,
+				col_bool BOOL,
+				col_bit BIT,
+				col_binary BINARY(255),
+				col_varbinary VARBINARY(255),
+				col_blob BLOB,
+				col_date DATE,
+				col_time TIME,
+				col_datetime DATETIME,
+				col_timestamp TIMESTAMP,
+				col_year YEAR,
+				col_enum ENUM('a', 'b', 'c'),
+				col_set SET('a', 'b', 'c'),
+				col_json JSON
+			)"
+		);
+
+		// Set non-strict mode.
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+
+		// INSERT.
+		$this->assertQuery(
+			"INSERT INTO t VALUES ('', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '')"
+		);
+
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+		$this->assertSame( '0', $result[0]->col_int );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? '0.0' : '0', $result[0]->col_float );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? '0.0' : '0', $result[0]->col_double );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? '0.0' : '0', $result[0]->col_decimal );
+		$this->assertSame( '', $result[0]->col_char );
+		$this->assertSame( '', $result[0]->col_varchar );
+		$this->assertSame( '', $result[0]->col_text );
+		$this->assertSame( '0', $result[0]->col_bool );
+		$this->assertSame( '0', $result[0]->col_bit );
+		$this->assertSame( '0', $result[0]->col_binary ); // TODO: Should save ''.
+		$this->assertSame( '', $result[0]->col_varbinary );
+		$this->assertSame( '', $result[0]->col_blob );
+		$this->assertSame( '0000-00-00', $result[0]->col_date );
+		$this->assertSame( '00:00:00', $result[0]->col_time );
+		$this->assertSame( '0000-00-00 00:00:00', $result[0]->col_datetime );
+		$this->assertSame( '0000-00-00 00:00:00', $result[0]->col_timestamp );
+		$this->assertSame( '0000', $result[0]->col_year );
+		$this->assertSame( '', $result[0]->col_enum );
+		$this->assertSame( '', $result[0]->col_set );
+		$this->assertSame( '', $result[0]->col_json ); // TODO: This should not be allowed.
+
+		// UPDATE.
+		$this->assertQuery(
+			"UPDATE t SET
+				col_int = '',
+				col_float = '',
+				col_double = '',
+				col_decimal = '',
+				col_char = '',
+				col_varchar = '',
+				col_text = '',
+				col_bool = '',
+				col_bit = '',
+				col_binary = '',
+				col_varbinary = '',
+				col_blob = '',
+				col_date = '',
+				col_time = '',
+				col_datetime = '',
+				col_timestamp = '',
+				col_year = '',
+				col_enum = '',
+				col_set = '',
+				col_json = ''
+			"
+		);
+
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+		$this->assertSame( '0', $result[0]->col_int );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? '0.0' : '0', $result[0]->col_float );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? '0.0' : '0', $result[0]->col_double );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? '0.0' : '0', $result[0]->col_decimal );
+		$this->assertSame( '', $result[0]->col_char );
+		$this->assertSame( '', $result[0]->col_varchar );
+		$this->assertSame( '', $result[0]->col_text );
+		$this->assertSame( '0', $result[0]->col_bool );
+		$this->assertSame( '0', $result[0]->col_bit );
+		$this->assertSame( '0', $result[0]->col_binary ); // TODO: Should save ''.
+		$this->assertSame( '', $result[0]->col_varbinary );
+		$this->assertSame( '', $result[0]->col_blob );
+		$this->assertSame( '0000-00-00', $result[0]->col_date );
+		$this->assertSame( '00:00:00', $result[0]->col_time );
+		$this->assertSame( '0000-00-00 00:00:00', $result[0]->col_datetime );
+		$this->assertSame( '0000-00-00 00:00:00', $result[0]->col_timestamp );
+		$this->assertSame( '0000', $result[0]->col_year );
+		$this->assertSame( '', $result[0]->col_enum );
+		$this->assertSame( '', $result[0]->col_set );
+		$this->assertSame( '', $result[0]->col_json ); // TODO: This should not be allowed.
+	}
+
 	public function testSessionSqlModes(): void {
 		// Syntax: "sql_mode" ("@@sql_mode" for SELECT)
 		$this->assertQuery( 'SET sql_mode = "ERROR_FOR_DIVISION_BY_ZERO"' );

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4622,9 +4622,9 @@ QUERY
 		$this->assertSame( '', $result[0]->col_text );
 		$this->assertSame( '0', $result[0]->col_bool );
 		$this->assertSame( '0', $result[0]->col_bit );
-		$this->assertSame( '0', $result[0]->col_binary ); // TODO: Should save ''.
-		$this->assertSame( '', $result[0]->col_varbinary );
-		$this->assertSame( '', $result[0]->col_blob );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? null : '', $result[0]->col_binary );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? null : '', $result[0]->col_varbinary );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? null : '', $result[0]->col_blob );
 		$this->assertSame( '0000-00-00', $result[0]->col_date );
 		$this->assertSame( '00:00:00', $result[0]->col_time );
 		$this->assertSame( '0000-00-00 00:00:00', $result[0]->col_datetime );
@@ -4671,9 +4671,9 @@ QUERY
 		$this->assertSame( '', $result[0]->col_text );
 		$this->assertSame( '0', $result[0]->col_bool );
 		$this->assertSame( '0', $result[0]->col_bit );
-		$this->assertSame( '0', $result[0]->col_binary ); // TODO: Should save ''.
-		$this->assertSame( '', $result[0]->col_varbinary );
-		$this->assertSame( '', $result[0]->col_blob );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? null : '', $result[0]->col_binary );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? null : '', $result[0]->col_varbinary );
+		$this->assertSame( PHP_VERSION_ID < 80100 ? null : '', $result[0]->col_blob );
 		$this->assertSame( '0000-00-00', $result[0]->col_date );
 		$this->assertSame( '00:00:00', $result[0]->col_time );
 		$this->assertSame( '0000-00-00 00:00:00', $result[0]->col_datetime );

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -3787,6 +3787,53 @@ QUERY
 		"
 		);
 
+		$result = $this->assertQuery( 'DESCRIBE t' );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'Field'   => 'name',
+					'Type'    => 'varchar(255)',
+					'Null'    => 'YES',
+					'Key'     => '',
+					'Default' => 'CURRENT_TIMESTAMP',
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'type',
+					'Type'    => 'varchar(255)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => 'DEFAULT',
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'description',
+					'Type'    => 'varchar(250)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => '',
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'created_at',
+					'Type'    => 'timestamp',
+					'Null'    => 'YES',
+					'Key'     => '',
+					'Default' => 'CURRENT_TIMESTAMP',
+					'Extra'   => 'DEFAULT_GENERATED',
+				),
+				(object) array(
+					'Field'   => 'updated_at',
+					'Type'    => 'timestamp',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => 'CURRENT_TIMESTAMP',
+					'Extra'   => 'DEFAULT_GENERATED on update CURRENT_TIMESTAMP',
+				),
+			),
+			$result
+		);
+
 		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
 		$this->assertEquals(
 			"CREATE TABLE `t` (\n"

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1110,7 +1110,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 	public function testBinaryDataTypes(): void {
 		$this->assertQuery(
-			'CREATE TABLE `t` ( `b` INTEGER, `v` BLOB ) STRICT',
+			'CREATE TABLE `t` ( `b` BLOB, `v` BLOB ) STRICT',
 			'CREATE TABLE t (b BINARY, v VARBINARY(255))'
 		);
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -745,12 +745,27 @@ class WP_SQLite_Driver {
 			 *
 			 * From the SQLite documentation:
 			 *
+			 *   ## Read transactions versus write transactions
+			 *
 			 *   If a write statement occurs while a read transaction is active,
 			 *   then the read transaction is upgraded to a write transaction if
 			 *   possible. If some other database connection has already modified
 			 *   the database or is already in the process of modifying the database,
 			 *   then upgrading to a write transaction is not possible and the write
 			 *   statement will fail with SQLITE_BUSY.
+			 *
+			 *   ## DEFERRED, IMMEDIATE, and EXCLUSIVE transactions
+			 *
+			 *   Transactions can be DEFERRED, IMMEDIATE, or EXCLUSIVE. The default
+			 *   transaction behavior is DEFERRED.
+			 *
+			 *   DEFERRED means that the transaction does not actually start until
+			 *   the database is first accessed.
+			 *
+			 *   IMMEDIATE causes the database connection to start a new write
+			 *   immediately, without waiting for a write statement. The BEGIN
+			 *   IMMEDIATE might fail with SQLITE_BUSY if another write transaction
+			 *   is already active on another database connection.
 			 *
 			 * See:
 			 *   - https://www.sqlite.org/lang_transaction.html

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2973,7 +2973,25 @@ class WP_SQLite_Driver {
 			}
 		}
 
-		// 3. Get the list of column names returned by VALUES or SELECT clause.
+		// 3. Filter out omitted columns that will get a value from the SQLite engine.
+		//    That is, nullable columns, columns with defaults, and generated columns.
+		$columns = array_values(
+			array_filter(
+				$columns,
+				function ( $column ) use ( $insert_list ) {
+					$is_omitted = ! in_array( $column['COLUMN_NAME'], $insert_list, true );
+					if ( ! $is_omitted ) {
+						return true;
+					}
+					$is_nullable  = 'YES' === $column['IS_NULLABLE'];
+					$has_default  = $column['COLUMN_DEFAULT'];
+					$is_generated = str_contains( $column['EXTRA'], 'auto_increment' );
+					return ! ( $is_nullable || $has_default || $is_generated );
+				}
+			)
+		);
+
+		// 4. Get the list of column names returned by VALUES or SELECT clause.
 		$select_list = array();
 		if ( 'insertQueryExpression' === $node->rule_name ) {
 			// When inserting from a SELECT query, we don't know the column names.
@@ -2994,7 +3012,7 @@ class WP_SQLite_Driver {
 			}
 		}
 
-		// 4. Compose a new INSERT field list with all columns from the table.
+		// 5. Compose a new INSERT field list with all columns from the table.
 		$fragment = '(';
 		foreach ( $columns as $i => $column ) {
 			$fragment .= $i > 0 ? ', ' : '';
@@ -3002,20 +3020,19 @@ class WP_SQLite_Driver {
 		}
 		$fragment .= ')';
 
-		// 5. Compose a wrapper SELECT statement emulating IMPLICIT DEFAULT values.
+		// 6. Compose a wrapper SELECT statement emulating IMPLICIT DEFAULT values.
 		$fragment .= ' SELECT ';
 		foreach ( $columns as $i => $column ) {
 			$is_omitted = ! in_array( $column['COLUMN_NAME'], $insert_list, true );
 			$fragment  .= $i > 0 ? ', ' : '';
 			if ( $is_omitted ) {
-				// When a column value is omitted from the INSERT statement, we
-				// need to use the DEFAULT value or the IMPLICIT DEFAULT value.
-				$is_auto_inc = str_contains( $column['EXTRA'], 'auto_increment' );
-				$is_nullable = 'YES' === $column['IS_NULLABLE'];
-				$default     = $column['COLUMN_DEFAULT'];
-				if ( null === $default && ! $is_nullable && ! $is_auto_inc ) {
-					$default = self::DATA_TYPE_IMPLICIT_DEFAULT_MAP[ $column['DATA_TYPE'] ] ?? null;
-				}
+				/*
+				 * When a column is omitted from the INSERT list, we need to use
+				 * an IMPLICIT DEFAULT value. Note that at this point, all omitted
+				 * columns that will not get an implicit default are filtered out.
+				 * (That is, nullable, generated, and columns with true defaults.)
+				 */
+				$default   = self::DATA_TYPE_IMPLICIT_DEFAULT_MAP[ $column['DATA_TYPE'] ] ?? null;
 				$fragment .= null === $default ? 'NULL' : $this->connection->quote( $default );
 			} else {
 				// When a column value is included, we need to apply type casting.

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -735,7 +735,31 @@ class WP_SQLite_Driver {
 	 */
 	public function begin_transaction(): void {
 		if ( 0 === $this->transaction_level ) {
-			$this->execute_sqlite_query( 'BEGIN' );
+			/*
+			 * When we're executing a statement that will write to the database,
+			 * we need to use "BEGIN IMMEDIATE" to open a write transaction.
+			 *
+			 * This is needed to avoid the "database is locked" error (SQLITE_BUSY)
+			 * when SQLite can't upgrade a read transaction to a write transaction,
+			 * because another connection is modifying the database.
+			 *
+			 * From the SQLite documentation:
+			 *
+			 *   If a write statement occurs while a read transaction is active,
+			 *   then the read transaction is upgraded to a write transaction if
+			 *   possible. If some other database connection has already modified
+			 *   the database or is already in the process of modifying the database,
+			 *   then upgrading to a write transaction is not possible and the write
+			 *   statement will fail with SQLITE_BUSY.
+			 *
+			 * See:
+			 *   - https://www.sqlite.org/lang_transaction.html
+			 *   - https://www.sqlite.org/rescode.html#busy
+			 *
+			 * For better performance, we could also consider opening the write
+			 * transaction later in the session - just before the first write.
+			 */
+			$this->execute_sqlite_query( $this->is_readonly ? 'BEGIN' : 'BEGIN IMMEDIATE' );
 		} else {
 			$this->execute_sqlite_query( 'SAVEPOINT LEVEL' . $this->transaction_level );
 		}

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -94,7 +94,7 @@ class WP_SQLite_Driver {
 		WP_MySQL_Lexer::YEAR_SYMBOL               => 'TEXT',
 
 		// Binary data types:
-		WP_MySQL_Lexer::BINARY_SYMBOL             => 'INTEGER',
+		WP_MySQL_Lexer::BINARY_SYMBOL             => 'BLOB',
 		WP_MySQL_Lexer::VARBINARY_SYMBOL          => 'BLOB',
 		WP_MySQL_Lexer::TINYBLOB_SYMBOL           => 'BLOB',
 		WP_MySQL_Lexer::BLOB_SYMBOL               => 'BLOB',
@@ -162,7 +162,7 @@ class WP_SQLite_Driver {
 		'year'               => 'TEXT',
 
 		// Binary data types:
-		'binary'             => 'INTEGER',
+		'binary'             => 'BLOB',
 		'varbinary'          => 'BLOB',
 		'tinyblob'           => 'BLOB',
 		'blob'               => 'BLOB',

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3018,9 +3018,14 @@ class WP_SQLite_Driver {
 				}
 				$fragment .= null === $default ? 'NULL' : $this->connection->quote( $default );
 			} else {
-				// When a column value is included, we can use it without change.
-				$position  = array_search( $column['COLUMN_NAME'], $insert_list, true );
-				$fragment .= $this->quote_sqlite_identifier( $select_list[ $position ] );
+				// When a column value is included, we need to apply type casting.
+				$position   = array_search( $column['COLUMN_NAME'], $insert_list, true );
+				$identifier = $this->quote_sqlite_identifier( $select_list[ $position ] );
+				$fragment  .= sprintf(
+					'%s AS %s',
+					$this->cast_value_in_non_strict_mode( $column['DATA_TYPE'], $identifier ),
+					$identifier
+				);
 			}
 		}
 
@@ -3095,6 +3100,9 @@ class WP_SQLite_Driver {
 				$value = $this->translate( $expr );
 			}
 
+			// Apply type casting.
+			$value = $this->cast_value_in_non_strict_mode( $data_type, $value );
+
 			// If the column is NOT NULL, a NULL value resolves to implicit default.
 			$implicit_default = self::DATA_TYPE_IMPLICIT_DEFAULT_MAP[ $data_type ] ?? null;
 			if ( ! $is_nullable && null !== $implicit_default ) {
@@ -3108,6 +3116,61 @@ class WP_SQLite_Driver {
 			$fragment .= $value;
 		}
 		return $fragment;
+	}
+
+	/**
+	 * Emulate MySQL type casting for INSERT or UPDATE value in non-strict mode.
+	 *
+	 * @param  string $mysql_data_type  The MySQL data type.
+	 * @param  string $translated_value The original translated value.
+	 * @return string                   The translated value.
+	 */
+	private function cast_value_in_non_strict_mode(
+		string $mysql_data_type,
+		string $translated_value
+	): string {
+		$sqlite_data_type = self::DATA_TYPE_STRING_MAP[ $mysql_data_type ];
+
+		// Get and quote the IMPLICIT DEFAULT value.
+		$implicit_default        = self::DATA_TYPE_IMPLICIT_DEFAULT_MAP[ $mysql_data_type ] ?? null;
+		$quoted_implicit_default = null === $implicit_default
+			? 'NULL'
+			: $this->connection->quote( $implicit_default );
+
+		/*
+		 * In MySQL, when saving a value via INSERT or UPDATE in non-strict mode,
+		 *   1. MySQL attempts to cast the value to the target column data type.
+		 *   2. When casting can't be done, MySQL saves an IMPLICIT DEFAULT.
+		 */
+		switch ( $mysql_data_type ) {
+			case 'date':
+			case 'time':
+			case 'datetime':
+			case 'timestamp':
+			case 'year':
+				if ( 'date' === $mysql_data_type ) {
+					$function_call = sprintf( 'DATE(%s)', $translated_value );
+				} elseif ( 'time' === $mysql_data_type ) {
+					$function_call = sprintf( 'TIME(%s)', $translated_value );
+				} elseif ( 'datetime' === $mysql_data_type || 'timestamp' === $mysql_data_type ) {
+					$function_call = sprintf( 'DATETIME(%s)', $translated_value );
+				} elseif ( 'year' === $mysql_data_type ) {
+					$function_call = sprintf( "STRFTIME('%%Y', %s)", $translated_value );
+				}
+
+				// When the function call evaluates to NULL (invalid date/time),
+				// we need to fallback to the IMPLICIT DEFAULT value.
+				return sprintf(
+					'IIF(%s IS NULL, NULL, COALESCE(%s, %s))',
+					$translated_value,
+					$function_call,
+					$quoted_implicit_default
+				);
+			default:
+				// For all other data types, use SQLite-native CAST expression.
+				$mysql_data_type = strtolower( $mysql_data_type );
+				return sprintf( 'CAST(%s AS %s)', $translated_value, $sqlite_data_type );
+		}
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3285,6 +3285,10 @@ class WP_SQLite_Driver {
 			 *     PRIMARY KEY without AUTOINCREMENT (to avoid the ROWID alias).
 			 *  2. Use "INTEGER PRIMARY KEY" otherwise.
 			 *
+			 * In SQLite, "AUTOINCREMENT" is only allowed on "INTEGER PRIMARY KEY",
+			 * and setting it changes the automatic ROWID assignment algorithm to
+			 * prevent the reuse of ROWIDs. Using "INT PRIMARY KEY" is not allowed.
+			 *
 			 * See:
 			 *   - https://www.sqlite.org/autoinc.html
 			 *   - https://www.sqlite.org/lang_createtable.html

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3165,6 +3165,20 @@ class WP_SQLite_Driver {
 			case 'datetime':
 			case 'timestamp':
 			case 'year':
+				/*
+				 * MySQL supports date and time components without a zero padding,
+				 * but that doesn't work with date and time functions in SQLite.
+				 * E.g.: "2025-3-7 9:5:2" is a valid datetime/timestamp value in
+				 * in MySQL, but SQLite requires it to be "2025-03-07 09:05:02".
+				 *
+				 * A solution to this would need to be done on the SQL level to
+				 * address computed values, and it should be done for the strict
+				 * mode as well. This may require a user-defined function.
+				 *
+				 * TODO: Handle zero padding for date and time functions, while
+				 *       supporting both strict and non-strict modes.
+				 */
+
 				if ( 'date' === $mysql_data_type ) {
 					$function_call = sprintf( 'DATE(%s)', $translated_value );
 				} elseif ( 'time' === $mysql_data_type ) {

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -1440,20 +1440,28 @@ class WP_SQLite_Information_Schema_Builder {
 			return 'auto_increment';
 		}
 
-		// Check whether DEFAULT value is an expression.
+		// AUTO_INCREMENT columns can't have a DEFAULT value.
+		foreach ( $attributes as $attr ) {
+			if ( $attr->has_child_token( WP_MySQL_Lexer::AUTO_INCREMENT_SYMBOL ) ) {
+				return 'auto_increment';
+			}
+		}
+
+		// Check whether DEFAULT value is generated.
 		foreach ( $attributes as $attr ) {
 			if (
 				$attr->has_child_token( WP_MySQL_Lexer::DEFAULT_SYMBOL )
-				&& $attr->has_child_node( 'exprWithParentheses' )
+				&& (
+					$attr->has_child_node( 'exprWithParentheses' )
+					|| $attr->has_child_token( WP_MySQL_Lexer::NOW_SYMBOL )
+				)
 			) {
 				$extras[] = 'DEFAULT_GENERATED';
 			}
 		}
 
+		// Check for ON UPDATE CURRENT_TIMESTAMP.
 		foreach ( $attributes as $attr ) {
-			if ( $attr->has_child_token( WP_MySQL_Lexer::AUTO_INCREMENT_SYMBOL ) ) {
-				return 'auto_increment';
-			}
 			if (
 				$attr->has_child_token( WP_MySQL_Lexer::ON_SYMBOL )
 				&& $attr->has_child_token( WP_MySQL_Lexer::UPDATE_SYMBOL )
@@ -1462,6 +1470,7 @@ class WP_SQLite_Information_Schema_Builder {
 			}
 		}
 
+		// Check for generated columns.
 		if ( $node->get_first_descendant_token( WP_MySQL_Lexer::VIRTUAL_SYMBOL ) ) {
 			$extras[] = 'VIRTUAL GENERATED';
 		} elseif ( $node->get_first_descendant_token( WP_MySQL_Lexer::STORED_SYMBOL ) ) {

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php
@@ -587,14 +587,24 @@ class WP_SQLite_Information_Schema_Reconstructor {
 	private function get_cached_mysql_data_type( string $table_name, string $column_or_index_name ): ?string {
 		try {
 			$mysql_type = $this->driver->execute_sqlite_query(
-				'SELECT mysql_type FROM _mysql_data_types_cache WHERE `table` = ? AND column_or_index = ?',
-				array( $table_name, $column_or_index_name )
+				'SELECT mysql_type FROM _mysql_data_types_cache
+				WHERE `table` = ? COLLATE NOCASE
+				AND (
+					-- The old SQLite driver stored the MySQL data types in multiple
+					-- formats - lowercase, uppercase, and, sometimes, with backticks.
+					column_or_index = ? COLLATE NOCASE
+					OR column_or_index = ? COLLATE NOCASE
+				)',
+				array( $table_name, $column_or_index_name, "`$column_or_index_name`" )
 			)->fetchColumn();
 		} catch ( PDOException $e ) {
 			if ( str_contains( $e->getMessage(), 'no such table' ) ) {
 				return null;
 			}
 			throw $e;
+		}
+		if ( false === $mysql_type ) {
+			return null;
 		}
 
 		// Normalize index type for backward compatibility. Some older versions


### PR DESCRIPTION
**List of discovered issues:**

- [x] Data types from `_mysql_data_types_cache` are sometimes not correctly fetched, as they can be saved in multiple formates (lowercase, uppercase, with or without backticks).
- [x] MySQL applies type casting when saving data in non-strict mode, resulting in things like empty string being saved as `0` for an integer, `0000-00-00 00:00:00` for a date, etc.
- [x] Functional defaults are incorrectly applied in non-strict mode (`DEFAULT CURRENT_TIMESTAMP` saves a `'CURRENT_TIMESTAMP'` string rather than the correct value).
- [x] MySQL `BINARY` type is saved as `INTEGER`, but it's actually a binary string, and `BLOB` would be more suitable.
- [x] MySQL supports date and time components without a zero padding, but that doesn't work with date and time functions in SQLite. (E.g.: `2025-3-7 9:5:2` is a valid datetime/timestamp value in MySQL, but SQLite requires it to be `2025-03-07 09:05:02`.)
- [x] In multi-process environments (php-fpm), concurrent writes can cause "SQLSTATE[HY000]: General error: 5 database is locked" (`SQLITE_BUSY`).